### PR TITLE
Fix documentation for sleep_lights + add passive_start doc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Below are the full config options:
 |`include_entities`|List of `entity_id`s that will be considered from this area. Useful for non-discovery MQTT and Template entities.            |`empty` (Area registry-tied entities only)            |
 |`exclude_entities`|List of `entity_id`s that will __NOT__ be considered from this area. Useful for excluding entities brought in by the Area Registry.            |`empty` (None)            |
 |`presence_sensor_device_class`|List of `device_class` of `binary_sensors` that will be considered as presence sensors. This override the default, does not adds on top. Make sure to list __ALL__ the `device_class` needed.            | `['motion','occupancy','presence']`            |
+|`passive_start`| Prevents actions from triggering upon first state change. Avoids triggering actions on HA restart.           |`True`             |
 |`exterior`| Mark area as exterior (patios, backyards, etc) for global aggregates.           |`False`             |
 |`clear_timeout`|Seconds the area should wait since the last presence sensor goes `off` until changing state to `clear`.            |`60`             |
 |`update_interval`|How often to check on the presence sensors (if `event_state_change` callback was missed).            |`15`             |
@@ -81,7 +82,7 @@ Below are the full config options:
 |`disable_state`|Entity state to disable automatic light control.				 |`on`             |
 |`sleep_entity`|Entity ID to enable sleep-mode for automatic light control.				 |`None`                   |
 |`sleep_state`|Entity state to enablle sleep-mode for automatic light control.				 |`on`             |
-|`sleep_entities`|List of entity_ids of lights to turn on when on sleep-mode.		 |`empty` (Required if `sleep_entity` is defined)             |
+|`sleep_lights`|List of entity_ids of lights to turn on when on sleep-mode.		 |`empty` (Required if `sleep_entity` is defined)             |
 
 ## Problems/bugs, questions, feature requests?
 


### PR DESCRIPTION
Fix documentation for `sleep_lights`. Added documentation for `passive_start`.

Closes #27 
Closes #37 