### PR TITLE
add more detail to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ If you think all of the above features are freaking awesome, **Magic Areas** is 
 
 ## Features
 * Uses multiple type of sensors for determining presence on an area.
-	* `media_player`,  `binary_sensors` (`motion`,`presence`,`occupancy`and `door`) are supported.
-* Loads areas from `Area Registry` -- _No need of handling them elsewhere!_.
+	* `media_player`,  `binary_sensors` ([all listed types](https://www.home-assistant.io/integrations/binary_sensor/)) are supported
 * Support inclusion of non-device-tied entities (non-discovery MQTT/Template sensors).
+    * It's necessary to specify a `unique_id` / `device_id` for these sensors if they are defined in yaml configuration.
 * Support exclusion of entities.
 * Automatic turn climates and lights on! (All or user-defined).
   * Specify a `disable_entity` for when lights *shouldn't* turn on (e.g. daytime, high luminance etc)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ If you think all of the above features are freaking awesome, **Magic Areas** is 
 ## Features
 * Uses multiple type of sensors for determining presence on an area.
 	* `media_player`,  `binary_sensors` ([all listed types](https://www.home-assistant.io/integrations/binary_sensor/)) are supported
+* Loads areas from `Area Registry` -- _No need of handling them elsewhere!_.
 * Support inclusion of non-device-tied entities (non-discovery MQTT/Template sensors).
     * It's necessary to specify a `unique_id` / `device_id` for these sensors if they are defined in yaml configuration.
 * Support exclusion of entities.


### PR DESCRIPTION
I added a `vibration` `binary_sensor` to detect room presence. At first it doesn't work...after some debugging I figured out that it's necessary to add the unique_id option to a yaml-defined binary_sensor. Only if this happens magic_areas loads it through the EntityRegistry. 

Additionally I changed the supported types for `binary_sensors` according to the code, every defined type is supported (e.g. `vibration`). Not every type would make sense to measure presence - but it's technically possible.