### PR TITLE
Presence hold timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,34 +57,35 @@ magic_areas:
 ```
 Below are the full config options:
 
-| Option         |Description                    |Default value                |
-|----------------|-------------------------------|-----------------------------|
-|`control_lights`|Automatically turn lights on/off on presence state change.            |`True`             |
-|`control_climate`|Automatically turn climate on/off on presence state change.            |`True`             |
-|`control_media`|Automatically turn media devices off on presence state clear.            |`True`             |
-|`automatic_lights`|(see `autolights` configuration options section)                     |(see `autolights` configuration options section)            |
-|`include_entities`|List of `entity_id`s that will be considered from this area. Useful for non-discovery MQTT and Template entities.            |`empty` (Area registry-tied entities only)            |
-|`exclude_entities`|List of `entity_id`s that will __NOT__ be considered from this area. Useful for excluding entities brought in by the Area Registry.            |`empty` (None)            |
-|`presence_sensor_device_class`|List of `device_class` of `binary_sensors` that will be considered as presence sensors. This override the default, does not adds on top. Make sure to list __ALL__ the `device_class` needed.            | `['motion','occupancy','presence']`            |
-|`passive_start`| Prevents actions from triggering upon first state change. Avoids triggering actions on HA restart.           |`True`             |
-|`exterior`| Mark area as exterior (patios, backyards, etc) for global aggregates.           |`False`             |
-|`clear_timeout`|Seconds the area should wait since the last presence sensor goes `off` until changing state to `clear`.            |`60`             |
-|`update_interval`|How often to check on the presence sensors (if `event_state_change` callback was missed).            |`15`             |
-|`on_states`|Which states are considered `on`.            |`['on','playing','home','open']`             |
-|`icon`|Area presence `binary_sensor` icon.            |`mdi:texture-box"`             |
+| Option                         | Description                                                                                                                                                                                   | Default value                                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `control_lights`               | Automatically turn lights on/off on presence state change.                                                                                                                                    | `True`                                           |
+| `control_climate`              | Automatically turn climate on/off on presence state change.                                                                                                                                   | `True`                                           |
+| `control_media`                | Automatically turn media devices off on presence state clear.                                                                                                                                 | `True`                                           |
+| `automatic_lights`             | (see `autolights` configuration options section)                                                                                                                                              | (see `autolights` configuration options section) |
+| `include_entities`             | List of `entity_id`s that will be considered from this area. Useful for non-discovery MQTT and Template entities.                                                                             | `empty` (Area registry-tied entities only)       |
+| `exclude_entities`             | List of `entity_id`s that will __NOT__ be considered from this area. Useful for excluding entities brought in by the Area Registry.                                                           | `empty` (None)                                   |
+| `presence_sensor_device_class` | List of `device_class` of `binary_sensors` that will be considered as presence sensors. This override the default, does not adds on top. Make sure to list __ALL__ the `device_class` needed. | `['motion','occupancy','presence']`              |
+| `passive_start`                | Prevents actions from triggering upon first state change. Avoids triggering actions on HA restart.                                                                                            | `True`                                           |
+| `exterior`                     | Mark area as exterior (patios, backyards, etc) for global aggregates.                                                                                                                         | `False`                                          |
+| `clear_timeout`                | Seconds the area should wait since the last presence sensor goes `off` until changing state to `clear`.                                                                                       | `60`                                             |
+| `presence_hold_timeout`        | Seconds until the `presence_hold` switch of the area gets automatically turned `off`. `None` = disabled                                                                                       | `None`                                           |
+| `update_interval`              | How often to check on the presence sensors (if `event_state_change` callback was missed).                                                                                                     | `15`                                             |
+| `on_states`                    | Which states are considered `on`.                                                                                                                                                             | `['on','playing','home','open']`                 |
+| `icon`                         | Area presence `binary_sensor` icon.                                                                                                                                                           | `mdi:texture-box"`                               |
 
 
 `autolights` configuration:
 
-| Option         |Description                    |Default value                |
-|----------------|-------------------------------|-----------------------------|
-|`entities`|List of entity_ids of lights to turn on. 					 |`empty` (All)             |
-|`disable_entity`|Entity ID to disable automatic light control.				 |`None`                   |
-|`disable_state`|Entity state to disable automatic light control.				 |`on`             |
-|`sleep_entity`|Entity ID to enable sleep-mode for automatic light control.				 |`None`                   |
-|`sleep_state`|Entity state to enablle sleep-mode for automatic light control.				 |`on`             |
-|`sleep_lights`|List of entity_ids of lights to turn on when on sleep-mode.		 |`empty` (Required if `sleep_entity` is defined)             |
-|`sleep_timeout`|Seconds the area should wait since the last presence sensor goes `off` until changing state to `clear` and sleep mode is activated.            |`None (clear_timeout)`             |
+| Option           | Description                                                                                                                         | Default value                                   |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `entities`       | List of entity_ids of lights to turn on.                                                                                            | `empty` (All)                                   |
+| `disable_entity` | Entity ID to disable automatic light control.                                                                                       | `None`                                          |
+| `disable_state`  | Entity state to disable automatic light control.                                                                                    | `on`                                            |
+| `sleep_entity`   | Entity ID to enable sleep-mode for automatic light control.                                                                         | `None`                                          |
+| `sleep_state`    | Entity state to enable sleep-mode for automatic light control.                                                                      | `on`                                            |
+| `sleep_lights`   | List of entity_ids of lights to turn on when on sleep-mode.                                                                         | `empty` (Required if `sleep_entity` is defined) |
+| `sleep_timeout`  | Seconds the area should wait since the last presence sensor goes `off` until changing state to `clear` and sleep mode is activated. | `None (clear_timeout)`                          |
 
 ## Problems/bugs, questions, feature requests?
 

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -1,3 +1,4 @@
+from typing import Optional
 import voluptuous as vol
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
@@ -65,6 +66,7 @@ CONF_ON_STATES, DEFAULT_ON_STATES = "on_states", [
     STATE_OPEN,
 ]  # cv.list
 CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT = "clear_timeout", 60  # cv.positive_int
+CONF_PRESENCE_HOLD_TIMEOUT = "presence_hold_timeout"  # cv.positive_int
 CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 15  # cv.positive_int
 CONF_ICON, DEFAULT_ICON = "icon", "mdi:texture-box"  # cv.string
 
@@ -155,6 +157,7 @@ _DOMAIN_SCHEMA = vol.Schema(
                     CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
                 ): cv.positive_int,
                 vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
+                vol.Optional(CONF_PRESENCE_HOLD_TIMEOUT, default=None): cv.positive_int,
             },
             None,
         )

--- a/custom_components/magic_areas/switch.py
+++ b/custom_components/magic_areas/switch.py
@@ -1,7 +1,6 @@
 DEPENDENCIES = ["magic_areas"]
 
 import logging
-from datetime import datetime, timedelta
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.switch import SwitchEntity
@@ -9,10 +8,7 @@ from homeassistant.const import (
     STATE_ON,
     EVENT_HOMEASSISTANT_STARTED,
 )
-from homeassistant.helpers.event import (
-    async_track_state_change,
-    async_track_time_interval,
-)
+from homeassistant.helpers.event import call_later
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import (
@@ -115,9 +111,8 @@ class AreaPresenceHoldSwitch(SwitchEntity, RestoreEntity):
             _LOGGER.debug(
                 f"Will reset hold for {self.entity_id=} after {reset_timeout}s"
             )
-            delta = timedelta(seconds=reset_timeout)
             self.tracking_listeners.append(
-                async_track_time_interval(self.hass, self.turn_off_switch, delta)
+                call_later(self.hass, reset_timeout, self.turn_off_switch)
             )
 
     def turn_on(self, **kwargs):


### PR DESCRIPTION
Add ability to specify a `presence_hold_timeout` to reset the presence hold switch to `off` after a specified time (seconds).

This is still work in progress....
@jseidl hope that this is a suitable feature. Maybe you have some guidance for me as I'm not that digged deep in HA component development.  

ToDo:

- Mechanism to follow up the timer after restarting HA
- Update the docs