### PR TITLE
Changed feature enabling/disabled to use new features parameter

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.util import slugify
 
 from .const import (
     _DOMAIN_SCHEMA,
+    CONF_ENABLED_FEATURES,
     CONF_EXCLUDE_ENTITIES,
     CONF_INCLUDE_ENTITIES,
     DOMAIN,
@@ -59,7 +60,7 @@ async def async_setup(hass, config):
 
         # Check if entity has `area_id` support
         area_id = None
-        if hasattr(entity_object, 'area_id'):
+        if hasattr(entity_object, "area_id"):
             area_id = entity_object.area_id
 
         # Skip entities without devices, add them to a standalone map
@@ -195,6 +196,10 @@ class MagicArea(object):
             _LOGGER.info(f"> {platform}: {ec}")
             for entity in entities:
                 _LOGGER.info(f"  - {entity.entity_id}")
+
+    def has_feature(self, feature):
+
+        return feature in self.config.get(CONF_ENABLED_FEATURES)
 
     # Filter (include/exclude) entities
     def filter_entities(self, area_entities, standalone_entities):

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -41,10 +41,10 @@ from .const import (
     CONF_AL_SLEEP_TIMEOUT,
     CONF_AUTO_LIGHTS,
     CONF_CLEAR_TIMEOUT,
-    CONF_CONTROL_CLIMATE,
-    CONF_CONTROL_LIGHTS,
-    CONF_CONTROL_MEDIA,
     CONF_EXTERIOR,
+    CONF_FEATURE_AGGREGATION,
+    CONF_FEATURE_CLIMATE_CONTROL,
+    CONF_FEATURE_LIGHT_CONTROL,
     CONF_ICON,
     CONF_ON_STATES,
     CONF_PRESENCE_SENSOR_DEVICE_CLASS,
@@ -53,6 +53,7 @@ from .const import (
     DISTRESS_STATES,
     MODULE_DATA,
     PRESENCE_DEVICE_COMPONENTS,
+    CONF_FeATURE_MEDIA_CONTROL,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -74,6 +75,10 @@ async def async_setup_platform(
 
     # Create distress sensors
     for area in areas:
+
+        # Check feature availability
+        if not area.has_feature(CONF_FEATURE_AGGREGATION):
+            continue
 
         if BINARY_SENSOR_DOMAIN not in area.entities.keys():
             continue
@@ -351,7 +356,7 @@ class AreaPresenceBinarySensor(BinarySensorEntity, RestoreEntity):
     def _get_autolights_state(self):
 
         if (
-            not self.area.config.get(CONF_CONTROL_LIGHTS)
+            not self.area.has_feature(CONF_FEATURE_LIGHT_CONTROL)
             or self._is_autolights_disabled()
         ):
             return AUTOLIGHTS_STATE_DISABLED
@@ -483,7 +488,7 @@ class AreaPresenceBinarySensor(BinarySensorEntity, RestoreEntity):
 
     def _lights_on(self):
         # Turn on lights, if configured
-        if self.area.config.get(CONF_CONTROL_LIGHTS) and self._has_entities(
+        if self.area.has_feature(CONF_FEATURE_LIGHT_CONTROL) and self._has_entities(
             LIGHT_DOMAIN
         ):
             self._autolights()
@@ -493,7 +498,7 @@ class AreaPresenceBinarySensor(BinarySensorEntity, RestoreEntity):
         self._lights_on()
 
         # Turn on climate, if configured
-        if self.area.config.get(CONF_CONTROL_CLIMATE) and self._has_entities(
+        if self.area.has_feature(CONF_FEATURE_CLIMATE_CONTROL) and self._has_entities(
             CLIMATE_DOMAIN
         ):
             service_data = {
@@ -505,7 +510,7 @@ class AreaPresenceBinarySensor(BinarySensorEntity, RestoreEntity):
 
     def _lights_off(self):
         # Turn off lights, if configured
-        if self.area.config.get(CONF_CONTROL_LIGHTS) and self._has_entities(
+        if self.area.has_feature(CONF_FEATURE_LIGHT_CONTROL) and self._has_entities(
             LIGHT_DOMAIN
         ):
             service_data = {
@@ -520,7 +525,7 @@ class AreaPresenceBinarySensor(BinarySensorEntity, RestoreEntity):
         self._lights_off()
 
         # Turn off climate, if configured
-        if self.area.config.get(CONF_CONTROL_CLIMATE) and self._has_entities(
+        if self.area.has_feature(CONF_FEATURE_CLIMATE_CONTROL) and self._has_entities(
             CLIMATE_DOMAIN
         ):
             service_data = {
@@ -531,7 +536,7 @@ class AreaPresenceBinarySensor(BinarySensorEntity, RestoreEntity):
             self.hass.services.call(CLIMATE_DOMAIN, SERVICE_TURN_OFF, service_data)
 
         # Turn off media, if configured
-        if self.area.config.get(CONF_CONTROL_MEDIA) and self._has_entities(
+        if self.area.has_feature(CONF_FeATURE_MEDIA_CONTROL) and self._has_entities(
             MEDIA_PLAYER_DOMAIN
         ):
             service_data = {

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -43,9 +43,7 @@ MAGIC_AREAS_COMPONENTS = [
 ]
 
 # Configuration parameters
-CONF_CONTROL_CLIMATE, DEFAULT_CONTROL_CLIMATE = "control_climate", True  # cv.boolean
-CONF_CONTROL_LIGHTS, DEFAULT_CONTROL_LIGHTS = "control_lights", True  # cv.boolean
-CONF_CONTROL_MEDIA, DEFAULT_CONTROL_MEDIA = "control_media", True  # cv.boolean
+CONF_ENABLED_FEATURES, DEFAULT_ENABLED_FEATURES = "features", []  # cv.list
 CONF_AUTO_LIGHTS = "automatic_lights"  # cv.entity_ids
 CONF_INCLUDE_ENTITIES = "include_entities"  # cv.entity_ids
 CONF_EXCLUDE_ENTITIES = "exclude_entities"  # cv.entity_ids
@@ -67,6 +65,23 @@ CONF_ON_STATES, DEFAULT_ON_STATES = "on_states", [
 CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT = "clear_timeout", 60  # cv.positive_int
 CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 15  # cv.positive_int
 CONF_ICON, DEFAULT_ICON = "icon", "mdi:texture-box"  # cv.string
+
+# features
+CONF_FEATURE_CLIMATE_CONTROL = "control_climate"
+CONF_FEATURE_LIGHT_CONTROL = "control_lights"
+CONF_FeATURE_MEDIA_CONTROL = "control_media"
+CONF_FEATURE_LIGHT_GROUPS = "light_groups"
+CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER = "area_aware_media_player"
+CONF_FEATURE_AGGREGATION = "aggregates"
+
+CONF_FEATURE_LIST = [
+    CONF_FEATURE_CLIMATE_CONTROL,
+    CONF_FEATURE_LIGHT_CONTROL,
+    CONF_FeATURE_MEDIA_CONTROL,
+    CONF_FEATURE_LIGHT_GROUPS,
+    CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER,
+    CONF_FEATURE_AGGREGATION,
+]
 
 # automatic_lights options
 CONF_AL_DISABLE_ENTITY = "disable_entity"
@@ -131,14 +146,8 @@ _DOMAIN_SCHEMA = vol.Schema(
         cv.slug: vol.Any(
             {
                 vol.Optional(
-                    CONF_CONTROL_CLIMATE, default=DEFAULT_CONTROL_CLIMATE
-                ): cv.boolean,
-                vol.Optional(
-                    CONF_CONTROL_LIGHTS, default=DEFAULT_CONTROL_LIGHTS
-                ): cv.boolean,
-                vol.Optional(
-                    CONF_CONTROL_MEDIA, default=DEFAULT_CONTROL_MEDIA
-                ): cv.boolean,
+                    CONF_ENABLED_FEATURES, default=DEFAULT_ENABLED_FEATURES
+                ): cv.ensure_list,
                 vol.Optional(CONF_AUTO_LIGHTS, default=dict): CONFIG_AL_SCHEMA,
                 vol.Optional(
                     CONF_PRESENCE_SENSOR_DEVICE_CLASS,

--- a/custom_components/magic_areas/sensor.py
+++ b/custom_components/magic_areas/sensor.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.event import (
 from .const import (
     AGGREGATE_SENSOR_CLASSES,
     CONF_EXTERIOR,
+    CONF_FEATURE_AGGREGATION,
     CONF_UPDATE_INTERVAL,
     MODULE_DATA,
 )
@@ -41,6 +42,11 @@ async def async_setup_platform(
     aggregate_sensors = []
     device_class_area_map = {}
     for area in areas:
+
+        # Check feature availability
+        if not area.has_feature(CONF_FEATURE_AGGREGATION):
+            continue
+
         available_device_classes = []
 
         # sensor Aggregates


### PR DESCRIPTION
This feature remove the following config options:
* `control_lights`
* `control_climate`
* `control_media`

Introduces a new parameter called `features` which is a list of feature names the user wants to enable for a given area. All features now come disabled by default.

In addition, feature name `aggregates` was added to support turning on/off sensor aggregates.

Users intending to keep the original features shall configure their YAML like the following example:
```
magic_areas:
    living_room:
        features:
            - control_lights
            - control_media
            - control_climate
            - aggregates
```

I'm working on how to set defaults for all areas but haven't arrived in a good solution yet. To come in a future update.

Closes #2 #18 