### PR TITLE
Removal of manual integration adding step

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -43,6 +43,10 @@ async def async_setup(hass, config):
     # Populate MagicAreas
     areas = list(area_registry.async_list_areas())
 
+    if DOMAIN not in config.keys():
+        _LOGGER.error(f"'magic_areas:' not defined on YAML. Aborting.")
+        return
+
     magic_areas_config = config[DOMAIN]
 
     # Check reserved names

--- a/custom_components/magic_areas/base.py
+++ b/custom_components/magic_areas/base.py
@@ -527,6 +527,9 @@ class MagicMetaArea(MagicArea):
             ):
                 for entities in area.entities.values():
                     for entity in entities:
+                        if not isinstance(entity["entity_id"], str):
+                            _LOGGER.warning(f"Entity ID is not a string: {entity['entity_id']}")
+                            continue
                         entity_list.append(entity["entity_id"])
 
         self.load_entity_list(entity_list)

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -18,7 +18,7 @@ from homeassistant.const import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_ON,
-    STATE_UNAVAILABLE
+    STATE_UNAVAILABLE,
 )
 from homeassistant.helpers.event import (
     async_track_state_change,
@@ -424,7 +424,6 @@ class AreaPresenceBinarySensor(BinarySensorBase):
                 self._state_on()
             else:
                 self._state_off()
-
 
     def _get_sensors_state(self):
 

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -44,29 +44,11 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        errors = {}
-
-        area_registry = await self.hass.helpers.area_registry.async_get_registry()
-        areas = area_registry.async_list_areas()
-
-        area_names = [area.name for area in areas]
-
-        if user_input is not None:
-            await self.async_set_unique_id(user_input[CONF_NAME])
-            self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=user_input[CONF_NAME], data=user_input)
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema({vol.Required(CONF_NAME): vol.In(area_names)}),
-            # data_schema=_AREA_SCHEMA,
-            errors=errors,
-        )
+        return self.async_abort(reason="not_supported")
 
     async def async_step_import(self, user_input=None):
         """Handle configuration by yaml file."""
         await self.async_set_unique_id(user_input[CONF_NAME])
-        _LOGGER.warning(f"-- MARK -- {self._async_current_entries()}")
         for entry in self._async_current_entries():
             if entry.unique_id == self.unique_id:
                 self.hass.config_entries.async_update_entry(entry, data=user_input)

--- a/custom_components/magic_areas/manifest.json
+++ b/custom_components/magic_areas/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "magic_areas",
   "name": "Magic Areas",
+  "version": "2.0.2",
   "documentation": "https://github.com/jseidl/magic-areas",
   "dependencies": [],
   "after_dependencies": ["template", "group", "binary_sensor", "sensor", "light", "media_player", "device_tracker", "discovery", "camera"],

--- a/custom_components/magic_areas/sensor.py
+++ b/custom_components/magic_areas/sensor.py
@@ -49,11 +49,15 @@ async def load_sensors(hass, async_add_entities, area):
     for entity in area.entities[SENSOR_DOMAIN]:
 
         if "device_class" not in entity.keys():
-            _LOGGER.warning(f"Entity {entity['entity_id']} does not have device_class defined")
+            _LOGGER.warning(
+                f"Entity {entity['entity_id']} does not have device_class defined"
+            )
             continue
 
         if "unit_of_measurement" not in entity.keys():
-            _LOGGER.warning(f"Entity {entity['entity_id']} does not have unit_of_measurement defined")
+            _LOGGER.warning(
+                f"Entity {entity['entity_id']} does not have unit_of_measurement defined"
+            )
             continue
 
         map_key = f"{entity['device_class']}/{entity['unit_of_measurement']}"

--- a/custom_components/magic_areas/translations/en.json
+++ b/custom_components/magic_areas/translations/en.json
@@ -1,5 +1,10 @@
 {
   "title": "Magic Areas",
+  "config": {
+    "abort": {
+      "not_supported": "This integration is automatically configured on load. You don't need to manually add the integration on this UI. Your Magic Areas should be already on the integrations page. Use Home Assistant's built-in areas to create new ones and manage entities."
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/custom_components/magic_areas/translations/en.json
+++ b/custom_components/magic_areas/translations/en.json
@@ -1,6 +1,7 @@
 {
   "title": "Magic Areas",
   "config": {
+    "step": {},
     "abort": {
       "not_supported": "This integration is automatically configured on load. You don't need to manually add the integration on this UI. Your Magic Areas should be already on the integrations page. Use Home Assistant's built-in areas to create new ones and manage entities."
     }


### PR DESCRIPTION
Integration loads by setting `magic_areas:` on the YAML. Shouldn't be added from the UI (only configured). 

Added abort step with descriptive error message and also magic areas will refuse to load if `magic_areas:` isn't defined on the YAML file.

Fixes #85 