### PR TITLE
Add active_areas attribute to aggregate binary sensors of meta areas

### DIFF
--- a/custom_components/magic_areas/base.py
+++ b/custom_components/magic_areas/base.py
@@ -214,9 +214,7 @@ class BinarySensorBase(MagicSensorBase, BinarySensorEntity, RestoreEntity):
                 active_sensors.append(sensor)
 
                 if self.area.is_meta():
-                    parent_area = self._get_parent_area(sensor)
-                    if parent_area is not None:
-                        active_areas.add(parent_area.name)
+                    active_areas.update(self._get_parent_areas(sensor))
 
         self._attributes["active_sensors"] = active_sensors
 
@@ -225,14 +223,15 @@ class BinarySensorBase(MagicSensorBase, BinarySensorEntity, RestoreEntity):
 
         return len(active_sensors) > 0
 
-    def _get_parent_area(self, entity_id):
+    def _get_parent_areas(self, entity_id):
+        parent_areas = []
         for area_info in self.hass.data[MODULE_DATA].values():
             area = area_info[DATA_AREA_OBJECT]
             if not area.is_meta():
                 for domain_entities in area.entities.values():
                     if entity_id in (e[ATTR_ENTITY_ID] for e in domain_entities):
-                        return area
-        return None
+                        parent_areas.append(area.name)
+        return parent_areas
 
 
 class AggregateBase(MagicSensorBase):

--- a/custom_components/magic_areas/base.py
+++ b/custom_components/magic_areas/base.py
@@ -4,7 +4,12 @@ from statistics import mean
 
 import voluptuous as vol
 from homeassistant.components.binary_sensor import BinarySensorEntity
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_ON, STATE_UNAVAILABLE
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    EVENT_HOMEASSISTANT_STARTED,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.event import (
     async_track_state_change,
@@ -188,6 +193,7 @@ class BinarySensorBase(MagicSensorBase, BinarySensorEntity, RestoreEntity):
     def _get_sensors_state(self):
 
         active_sensors = []
+        active_areas = set()
 
         # Loop over all entities and check their state
         for sensor in self.sensors:
@@ -207,9 +213,26 @@ class BinarySensorBase(MagicSensorBase, BinarySensorEntity, RestoreEntity):
             if entity.state in STATE_ON:
                 active_sensors.append(sensor)
 
+                if self.area.is_meta():
+                    parent_area = self._get_parent_area(sensor)
+                    if parent_area is not None:
+                        active_areas.add(parent_area.name)
+
         self._attributes["active_sensors"] = active_sensors
 
+        if self.area.is_meta():
+            self._attributes["active_areas"] = list(active_areas)
+
         return len(active_sensors) > 0
+
+    def _get_parent_area(self, entity_id):
+        for area_info in self.hass.data[MODULE_DATA].values():
+            area = area_info[DATA_AREA_OBJECT]
+            if not area.is_meta():
+                for domain_entities in area.entities.values():
+                    if entity_id in (e[ATTR_ENTITY_ID] for e in domain_entities):
+                        return area
+        return None
 
 
 class AggregateBase(MagicSensorBase):

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -448,17 +448,9 @@ class AreaPresenceBinarySensor(BinarySensorBase):
 
             if entity.state in self.area.config.get(CONF_ON_STATES):
                 active_sensors.append(sensor)
-                if self.area.is_meta():
-                    parent_area = self._get_parent_area(sensor)
-                    if parent_area is not None:
-                        active_areas.add(parent_area.name)
 
-                # for area_info in self.hass.data[MODULE_DATA].values():
-                #     area = area_info[DATA_AREA_OBJECT]
-                #     if area.id not in (meta_area.lower() for meta_area in META_AREAS):
-                #         for component, entities in area.entities.items():
-                #             if (component in PRESENCE_DEVICE_COMPONENTS and sensor in (e[ATTR_ENTITY_ID] for e in entities)):
-                #                 active_areas.add(area.name)
+                if self.area.is_meta():
+                    active_areas.update(self._get_parent_areas(sensor))
 
         self._attributes["active_sensors"] = active_sensors
         if self.area.is_meta():


### PR DESCRIPTION
Can be used in automations to quickly get a list of which areas have active sensors without having to manually specify all areas to check/loop through.