### PR TITLE
Add support for cover groups

### DIFF
--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -14,6 +14,7 @@ from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_WINDOW,
 )
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
@@ -65,6 +66,7 @@ DATA_UNDO_UPDATE_LISTENER = "undo_update_listener"
 # MagicAreas Components
 MAGIC_AREAS_COMPONENTS = [
     BINARY_SENSOR_DOMAIN,
+    COVER_DOMAIN,
     SWITCH_DOMAIN,
     SENSOR_DOMAIN,
     LIGHT_DOMAIN,
@@ -72,6 +74,7 @@ MAGIC_AREAS_COMPONENTS = [
 
 MAGIC_AREAS_COMPONENTS_META = [
     BINARY_SENSOR_DOMAIN,
+    COVER_DOMAIN,
     SENSOR_DOMAIN,
     LIGHT_DOMAIN,
 ]
@@ -125,6 +128,7 @@ CONF_FEATURE_CLIMATE_CONTROL = "control_climate"
 CONF_FEATURE_LIGHT_CONTROL = "control_lights"
 CONF_FEATURE_MEDIA_CONTROL = "control_media"
 CONF_FEATURE_LIGHT_GROUPS = "light_groups"
+CONF_FEATURE_COVER_GROUPS = "cover_groups"
 CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER = "area_aware_media_player"
 CONF_FEATURE_AGGREGATION = "aggregates"
 CONF_FEATURE_HEALTH = "health"
@@ -134,12 +138,14 @@ CONF_FEATURE_LIST = [
     CONF_FEATURE_LIGHT_CONTROL,
     CONF_FEATURE_MEDIA_CONTROL,
     CONF_FEATURE_LIGHT_GROUPS,
+    CONF_FEATURE_COVER_GROUPS,
     CONF_FEATURE_AGGREGATION,
     CONF_FEATURE_HEALTH,
 ]
 
 CONF_FEATURE_LIST_META = [
     CONF_FEATURE_LIGHT_GROUPS,
+    CONF_FEATURE_COVER_GROUPS,
     CONF_FEATURE_AGGREGATION,
     CONF_FEATURE_HEALTH,
 ]

--- a/custom_components/magic_areas/cover.py
+++ b/custom_components/magic_areas/cover.py
@@ -1,0 +1,73 @@
+DEPENDENCIES = ["magic_areas"]
+
+import logging
+
+import homeassistant.components.cover as cover
+from homeassistant.components.group.cover import CoverGroup
+
+from .base import MagicEntity
+from .const import (
+    CONF_AGGREGATES_MIN_ENTITIES,
+    CONF_FEATURE_COVER_GROUPS,
+    DATA_AREA_OBJECT,
+    MODULE_DATA,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(hass, config_entry, async_add_entities):
+    """Set up the Area config entry."""
+
+    area_data = hass.data[MODULE_DATA][config_entry.entry_id]
+    area = area_data[DATA_AREA_OBJECT]
+
+    # Check feature availability
+    if not area.has_feature(CONF_FEATURE_COVER_GROUPS):
+        return
+
+    # Check if there are any covers
+    if not area.has_entities(cover.DOMAIN):
+        _LOGGER.debug(f"No {cover.DOMAIN} entities for area {area.name} ")
+        return
+
+    entities_to_add = []
+
+    # Append None to the list of device classes to catch those covers that
+    # don't have a device class assigned (and put them in their own group)
+    for device_class in cover.DEVICE_CLASSES + [None]:
+        covers_in_device_class = [
+            e["entity_id"]
+            for e in area.entities[cover.DOMAIN]
+            if e.get("device_class") == device_class
+        ]
+
+        if any(covers_in_device_class):
+            _LOGGER.debug(
+                f"Creating {device_class or ''} cover group for {area.name} with covers: {covers_in_device_class}"
+            )
+            entities_to_add.append(AreaCoverGroup(hass, area, device_class))
+    async_add_entities(entities_to_add)
+
+
+class AreaCoverGroup(MagicEntity, CoverGroup):
+    def __init__(self, hass, area, device_class):
+        self.area = area
+        self.hass = hass
+        self._name = (
+            f"{area.name} {device_class.title()} Covers"
+            if device_class
+            else f"{area.name} Covers"
+        )
+        self._device_class = device_class
+        self._entities = [
+            e
+            for e in area.entities[cover.DOMAIN]
+            if e.get("device_class") == device_class
+        ]
+
+        CoverGroup.__init__(self, self._name, [e["entity_id"] for e in self._entities])
+
+    @property
+    def device_class(self):
+        return self._device_class

--- a/custom_components/magic_areas/cover.py
+++ b/custom_components/magic_areas/cover.py
@@ -65,8 +65,9 @@ class AreaCoverGroup(MagicEntity, CoverGroup):
             for e in area.entities[cover.DOMAIN]
             if e.get("device_class") == device_class
         ]
+        self._attributes["covers"] = [e["entity_id"] for e in self._entities]
 
-        CoverGroup.__init__(self, self._name, [e["entity_id"] for e in self._entities])
+        CoverGroup.__init__(self, self._name, self._attributes["covers"])
 
     @property
     def device_class(self):


### PR DESCRIPTION
This adds support for grouping multiple covers in an area (similar to the light_groups feature).

Individual groups are created depending on the device_class of the covers (i.e. shades re put into one group, curtains into another).

Inheritance from CoverGroup is there to enable editing the resulting groups in the entity registry, because CoverGroup itself does not provide unique_ids.