### PR TITLE
Multiple steps in options flow

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -60,7 +60,7 @@ async def async_setup(hass, config):
 
     # Add Meta Areas to area list
     for meta_area in META_AREAS:
-        areas.append(AreaEntry(name=meta_area, id=meta_area.lower()))
+        areas.append(AreaEntry(name=meta_area, normalized_name=meta_area, id=meta_area.lower()))
 
     for area in areas:
 

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -10,14 +10,15 @@ from homeassistant.core import callback
 
 from .const import (
     ALL_BINARY_SENSOR_DEVICE_CLASSES,
-    AREA_TYPE_EXTERIOR,
-    AREA_TYPE_INTERIOR,
     AREA_TYPE_META,
     CONF_ENABLED_FEATURES,
     CONF_EXCLUDE_ENTITIES,
     CONF_FEATURE_LIST,
     CONF_FEATURE_LIST_GLOBAL,
     CONF_FEATURE_LIST_META,
+    CONF_FEATURE_LIGHT_GROUPS,
+    CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER,
+    CONF_FEATURE_AGGREGATION,
     CONF_INCLUDE_ENTITIES,
     CONF_MAIN_LIGHTS,
     CONF_NIGHT_ENTITY,
@@ -26,15 +27,23 @@ from .const import (
     CONF_SLEEP_ENTITY,
     CONF_SLEEP_LIGHTS,
     CONF_TYPE,
+    CONFIGURABLE_FEATURES,
     DATA_AREA_OBJECT,
     DOMAIN,
     META_AREA_GLOBAL,
+    META_AREA_SCHEMA,
     MODULE_DATA,
-    VALIDATION_TUPLES,
-    VALIDATION_TUPLES_META,
+    OPTIONS_AREA,
+    OPTIONS_AREA_META,
+    OPTIONS_LIGHT_GROUP,
+    OPTIONS_AGGREGATES,
+    OPTIONS_AREA_AWARE_MEDIA_PLAYER,
+    REGULAR_AREA_SCHEMA,
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+EMPTY_ENTRY = [""]
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -44,7 +53,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
-        
+
         if user_input is not None:
             await self.async_set_unique_id(user_input[CONF_NAME])
             self._abort_if_unique_id_configured()
@@ -74,72 +83,214 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: config_entries.ConfigEntry):
         """Initialize options flow."""
         self.config_entry = config_entry
+        self.data = None
+        self.area = None
+        self.all_entities = []
+        self.all_lights = []
+        self.all_media_players = []
+        self.selected_features = []
+        self.features_to_configure = None
+
+    def _build_options_schema(self, options, old_options=None, dynamic_validators={}):
+        _LOGGER.debug(
+            f"Building schema from options: {options} - dynamic_validators: {dynamic_validators}"
+        )
+        if old_options is None:
+            old_options = self.config_entry.options
+        _LOGGER.debug(f"Data for pre-populating fields: {old_options}")
+        schema = vol.Schema(
+            {
+                vol.Optional(
+                    name,
+                    description={"suggested_value": old_options.get(name)},
+                    default=default,
+                ): dynamic_validators.get(name, validation)
+                for name, default, validation in options
+            }
+        )
+        _LOGGER.debug(f"Built schema: {schema}")
+        return schema
 
     async def async_step_init(self, user_input=None):
-        """Handle options flow."""
-        conf = self.config_entry
-        if conf.source == config_entries.SOURCE_IMPORT:
-            return self.async_show_form(step_id="init", data_schema=None)
+        """Initialize the options flow"""
+        self.data = self.hass.data[MODULE_DATA][self.config_entry.entry_id]
+        self.area = self.data[DATA_AREA_OBJECT]
+
+        _LOGGER.debug(f"Initializing options flow for area {self.area.name}")
+        _LOGGER.debug(f"Old options in config entry: {self.config_entry.options}")
+
+        self.all_entities = sorted(self.hass.states.async_entity_ids())
+        self.all_lights = sorted(
+            entity["entity_id"] for entity in self.area.entities.get(LIGHT_DOMAIN, [])
+        )
+        self.all_media_players = sorted(
+            entity["entity_id"]
+            for entity in self.area.entities.get(MEDIA_PLAYER_DOMAIN, [])
+        )
+
+        return await self.async_step_area_config()
+
+    async def async_step_area_config(self, user_input=None):
+        """Gather basic settings for the area."""
         errors = {}
-
         if user_input is not None:
-            # validate_options(user_input, errors)
-            if not errors:
-                return self.async_create_entry(title="", data=user_input)
-
-        # Fetch area entities
-        data = self.hass.data[MODULE_DATA][self.config_entry.entry_id]
-        area = data[DATA_AREA_OBJECT]
-        area_type = area.config.get(CONF_TYPE)
-
-        feature_list = CONF_FEATURE_LIST
-
-        _VALIDATION_TUPLES = VALIDATION_TUPLES
-
-        if area_type == AREA_TYPE_META:
-            _VALIDATION_TUPLES = VALIDATION_TUPLES_META
-            feature_list = CONF_FEATURE_LIST_META
-
-        if area.id == META_AREA_GLOBAL.lower():
-            feature_list = CONF_FEATURE_LIST_GLOBAL
-
-        all_lights = (
-            [light["entity_id"] for light in area.entities[LIGHT_DOMAIN]]
-            if LIGHT_DOMAIN in area.entities.keys()
-            else []
-        )
-        all_media_players = (
-            [
-                media_player["entity_id"]
-                for media_player in area.entities[MEDIA_PLAYER_DOMAIN]
-            ]
-            if MEDIA_PLAYER_DOMAIN in area.entities.keys()
-            else []
-        )
-        all_entities = [entity for entity in self.hass.states.async_entity_ids()]
-        entity_list = cv.multi_select(sorted(all_entities))
-        empty_entry = [""]
-        to_replace = {
-            CONF_INCLUDE_ENTITIES: entity_list,
-            CONF_EXCLUDE_ENTITIES: entity_list,
-            CONF_ENABLED_FEATURES: cv.multi_select(sorted(feature_list)),
-            CONF_PRESENCE_SENSOR_DEVICE_CLASS: cv.multi_select(
-                sorted(ALL_BINARY_SENSOR_DEVICE_CLASSES)
-            ),
-            CONF_NOTIFICATION_DEVICES: cv.multi_select(sorted(all_media_players)),
-            CONF_MAIN_LIGHTS: cv.multi_select(sorted(all_lights)),
-            CONF_SLEEP_LIGHTS: cv.multi_select(sorted(all_lights)),
-            CONF_NIGHT_ENTITY: vol.In(sorted(empty_entry + all_entities)),
-            CONF_SLEEP_ENTITY: vol.In(sorted(empty_entry + all_entities)),
-            CONF_TYPE: vol.In(sorted([AREA_TYPE_INTERIOR, AREA_TYPE_EXTERIOR])),
-        }
-
-        options_schema = {}
-        for name, default, validation in _VALIDATION_TUPLES:
-            key = vol.Optional(name, default=conf.options.get(name, default))
-            value = to_replace.get(name, validation)
-            options_schema[key] = value
+            _LOGGER.debug(f"Validating area base config: {user_input}")
+            area_schema = (
+                META_AREA_SCHEMA
+                if self.area.config.get(CONF_TYPE) == AREA_TYPE_META
+                else REGULAR_AREA_SCHEMA
+            )
+            try:
+                self.area_options = area_schema(user_input)
+            except vol.MultipleInvalid as validation:
+                errors = {error.path[0]: error.msg for error in validation.errors}
+                _LOGGER.debug(f"Found the following errors: {errors}")
+            else:
+                _LOGGER.debug(f"Saving area base config: {self.area_options}")
+                return await self.async_step_select_features()
 
         return self.async_show_form(
-            step_id="init", data_schema=vol.Schema(options_schema), errors=errors
+            step_id="area_config",
+            data_schema=self._build_options_schema(
+                options=(
+                    OPTIONS_AREA_META
+                    if self.area.config.get(CONF_TYPE) == AREA_TYPE_META
+                    else OPTIONS_AREA
+                ),
+                dynamic_validators={
+                    CONF_INCLUDE_ENTITIES: cv.multi_select(self.all_entities),
+                    CONF_EXCLUDE_ENTITIES: cv.multi_select(self.all_entities),
+                    CONF_PRESENCE_SENSOR_DEVICE_CLASS: cv.multi_select(
+                        sorted(ALL_BINARY_SENSOR_DEVICE_CLASSES)
+                    ),
+                },
+            ),
+            errors=errors,
+        )
+
+    async def async_step_select_features(self, user_input=None):
+        """Ask the user to select features to enable for the area."""
+        if user_input is not None:
+            self.selected_features = [
+                feature for feature, is_selected in user_input.items() if is_selected
+            ]
+            self.features_to_configure = list(
+                set(self.selected_features) & set(CONFIGURABLE_FEATURES.keys())
+            )
+            _LOGGER.debug(f"Selected features: {self.selected_features}")
+            self.area_options[CONF_ENABLED_FEATURES].update(
+                {
+                    feature: {}
+                    for feature in self.selected_features
+                    if feature not in self.features_to_configure
+                }
+            )
+            return await self.async_route_feature_config()
+
+        feature_list = CONF_FEATURE_LIST
+        area_type = self.area.config.get(CONF_TYPE)
+        if area_type == AREA_TYPE_META:
+            feature_list = CONF_FEATURE_LIST_META
+        if self.area.id == META_AREA_GLOBAL.lower():
+            feature_list = CONF_FEATURE_LIST_GLOBAL
+
+        _LOGGER.debug(f"Selecting features from {feature_list}")
+
+        return self.async_show_form(
+            step_id="select_features",
+            data_schema=self._build_options_schema(
+                options=[(feature, False, bool) for feature in feature_list],
+                old_options={
+                    feature: (
+                        feature
+                        in self.config_entry.options.get(CONF_ENABLED_FEATURES, {})
+                    )
+                    for feature in feature_list
+                },
+            ),
+        )
+
+    async def async_route_feature_config(self, user_input=None):
+        """Determine the next feature to be configured or finalize the options
+        flow if there are no more features left (i.e. all selected features have
+        been configured)."""
+        _LOGGER.debug(f"Features yet to configure: {self.features_to_configure}")
+        _LOGGER.debug(f"Current config is: {self.area_options}")
+        if self.features_to_configure:
+            current_feature = self.features_to_configure.pop()
+            _LOGGER.debug(
+                f"Initiating configuration step for feature {current_feature}"
+            )
+            feature_conf_step = getattr(
+                self, f"async_step_feature_conf_{current_feature}"
+            )
+            return await feature_conf_step()
+        else:
+            _LOGGER.debug(
+                f"All features configured, saving config: {self.area_options}"
+            )
+            return self.async_create_entry(title="", data=self.area_options)
+
+    async def async_step_feature_conf_light_groups(self, user_input=None):
+        """Configure the light groups feature"""
+        return await self.do_feature_config(
+            name=CONF_FEATURE_LIGHT_GROUPS,
+            options=OPTIONS_LIGHT_GROUP,
+            dynamic_validators={
+                CONF_MAIN_LIGHTS: cv.multi_select(self.all_lights),
+                CONF_SLEEP_LIGHTS: cv.multi_select(self.all_lights),
+                CONF_NIGHT_ENTITY: vol.In(EMPTY_ENTRY + self.all_entities),
+                CONF_SLEEP_ENTITY: vol.In(EMPTY_ENTRY + self.all_entities),
+            },
+            user_input=user_input,
+        )
+
+    async def async_step_feature_conf_area_aware_media_player(self, user_input=None):
+        """Configure the area aware media player feature"""
+        return await self.do_feature_config(
+            name=CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER,
+            options=OPTIONS_AREA_AWARE_MEDIA_PLAYER,
+            dynamic_validators={
+                CONF_NOTIFICATION_DEVICES: cv.multi_select(self.all_media_players),
+            },
+            user_input=user_input,
+        )
+
+    async def async_step_feature_conf_aggregates(self, user_input=None):
+        """Configure the sensor aggregates feature"""
+        return await self.do_feature_config(
+            name=CONF_FEATURE_AGGREGATION,
+            options=OPTIONS_AGGREGATES,
+            user_input=user_input,
+        )
+
+    async def do_feature_config(
+        self, name, options, dynamic_validators={}, user_input=None
+    ):
+        """Execute step for a generic feature"""
+        errors = {}
+        if user_input is not None:
+            _LOGGER.debug(f"Validating {name} feature config: {user_input}")
+            try:
+                validated_input = CONFIGURABLE_FEATURES[name](user_input)
+            except vol.MultipleInvalid as validation:
+                errors = {
+                    error.path[0]: "malformed_input" for error in validation.errors
+                }
+                _LOGGER.debug(f"Found the following errors: {errors}")
+            else:
+                _LOGGER.debug(f"Saving {name} feature config: {validated_input}")
+                self.area_options[CONF_ENABLED_FEATURES][name] = validated_input
+                return await self.async_route_feature_config()
+
+        return self.async_show_form(
+            step_id=f"feature_conf_{name}",
+            data_schema=self._build_options_schema(
+                options=options,
+                old_options=self.config_entry.options.get(
+                    CONF_ENABLED_FEATURES, {}
+                ).get(name, {}),
+                dynamic_validators=dynamic_validators,
+            ),
+            errors=errors,
         )

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -1,4 +1,5 @@
 import voluptuous as vol
+from itertools import chain
 from homeassistant.components.binary_sensor import (
     DEVICE_CLASS_DOOR,
     DEVICE_CLASS_GAS,
@@ -137,21 +138,17 @@ CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER = "area_aware_media_player"
 CONF_FEATURE_AGGREGATION = "aggregates"
 CONF_FEATURE_HEALTH = "health"
 
-CONF_FEATURE_LIST = [
-    CONF_FEATURE_CLIMATE_CONTROL,
-    CONF_FEATURE_LIGHT_CONTROL,
-    CONF_FEATURE_MEDIA_CONTROL,
+CONF_FEATURE_LIST_META = [
     CONF_FEATURE_LIGHT_GROUPS,
     CONF_FEATURE_COVER_GROUPS,
     CONF_FEATURE_AGGREGATION,
     CONF_FEATURE_HEALTH,
 ]
 
-CONF_FEATURE_LIST_META = [
-    CONF_FEATURE_LIGHT_GROUPS,
-    CONF_FEATURE_COVER_GROUPS,
-    CONF_FEATURE_AGGREGATION,
-    CONF_FEATURE_HEALTH,
+CONF_FEATURE_LIST = CONF_FEATURE_LIST_META + [
+    CONF_FEATURE_CLIMATE_CONTROL,
+    CONF_FEATURE_LIGHT_CONTROL,
+    CONF_FEATURE_MEDIA_CONTROL,
 ]
 
 CONF_FEATURE_LIST_GLOBAL = CONF_FEATURE_LIST_META + [
@@ -204,46 +201,88 @@ AGGREGATE_MODE_SUM = [DEVICE_CLASS_POWER, DEVICE_CLASS_CURRENT, DEVICE_CLASS_ENE
 
 # Config Schema
 
+AGGREGATE_FEATURE_SCHEMA = vol.Schema({
+    vol.Optional(
+        CONF_AGGREGATES_MIN_ENTITIES, default=DEFAULT_AGGREGATES_MIN_ENTITIES
+    ): cv.positive_int,
+})
+
+LIGHT_GROUP_FEATURE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_MAIN_LIGHTS, default=[]): cv.entity_ids,
+    vol.Optional(CONF_SLEEP_LIGHTS, default=[]): cv.entity_ids,
+    vol.Optional(CONF_SLEEP_ENTITY, default=""): vol.Any("", cv.entity_id),
+    vol.Optional(CONF_SLEEP_STATE, default=DEFAULT_SLEEP_STATE): str,
+    vol.Optional(CONF_NIGHT_ENTITY, default=""): vol.Any("", cv.entity_id),
+    vol.Optional(CONF_NIGHT_STATE, default=DEFAULT_NIGHT_STATE): str,
+})
+
+AREA_AWARE_MEDIA_PLAYER_FEATURE_SCHEMA = vol.Schema({
+    vol.Optional(CONF_NOTIFICATION_DEVICES, default=[]): cv.entity_ids,
+    vol.Optional(CONF_NOTIFY_ON_SLEEP, default=DEFAULT_NOTIFY_ON_SLEEP): bool,
+})
+
+ALL_FEATURES = set(CONF_FEATURE_LIST) | set(CONF_FEATURE_LIST_GLOBAL)
+
+CONFIGURABLE_FEATURES = {
+    CONF_FEATURE_LIGHT_GROUPS: LIGHT_GROUP_FEATURE_SCHEMA,
+    CONF_FEATURE_AGGREGATION: AGGREGATE_FEATURE_SCHEMA,
+    CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER: AREA_AWARE_MEDIA_PLAYER_FEATURE_SCHEMA,
+}
+
+NON_CONFIGURABLE_FEATURES = {
+    feature: {}
+    for feature in ALL_FEATURES
+    if feature not in CONFIGURABLE_FEATURES.keys()
+}
+
+FEATURES_SCHEMA = vol.Schema({
+    vol.Optional(feature): feature_schema
+    for feature, feature_schema
+    in chain(CONFIGURABLE_FEATURES.items(), NON_CONFIGURABLE_FEATURES.items())
+})
+
 # Magic Areas
-_AREA_SCHEMA = {
-    # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_ENABLED_FEATURES, default=[]): cv.ensure_list,
+REGULAR_AREA_SCHEMA = vol.Schema({
+    vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): vol.In([AREA_TYPE_INTERIOR, AREA_TYPE_EXTERIOR]),
+    vol.Optional(CONF_INCLUDE_ENTITIES, default=[]): cv.entity_ids,
+    vol.Optional(CONF_EXCLUDE_ENTITIES, default=[]): cv.entity_ids,
     vol.Optional(
         CONF_PRESENCE_SENSOR_DEVICE_CLASS,
         default=DEFAULT_PRESENCE_DEVICE_SENSOR_CLASS,
     ): cv.ensure_list,
-    vol.Optional(CONF_INCLUDE_ENTITIES, default=[]): cv.entity_ids,
-    vol.Optional(CONF_EXCLUDE_ENTITIES, default=[]): cv.entity_ids,
-    vol.Optional(CONF_TYPE, default=DEFAULT_TYPE): str,
-    vol.Optional(CONF_ON_STATES, default=DEFAULT_ON_STATES): cv.ensure_list,
+    vol.Optional(CONF_ON_STATES, default=[]): cv.ensure_list_csv,
+    vol.Optional(CONF_CLEAR_TIMEOUT, default=DEFAULT_CLEAR_TIMEOUT): cv.positive_int,
+    vol.Optional(CONF_SLEEP_TIMEOUT, default=DEFAULT_SLEEP_TIMEOUT): cv.positive_int,
     vol.Optional(
-        CONF_AGGREGATES_MIN_ENTITIES, default=DEFAULT_AGGREGATES_MIN_ENTITIES
+        CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
     ): cv.positive_int,
+    vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
+    vol.Optional(CONF_ENABLED_FEATURES, default={}): FEATURES_SCHEMA,
+})
+
+META_AREA_SCHEMA = vol.Schema({
+    vol.Optional(CONF_TYPE, default=AREA_TYPE_META): AREA_TYPE_META,
+    vol.Optional(CONF_ENABLED_FEATURES, default={}): FEATURES_SCHEMA,
+    vol.Optional(CONF_EXCLUDE_ENTITIES, default=[]): cv.entity_ids,
+    vol.Optional(CONF_ON_STATES, default=[]): cv.ensure_list_csv,
     vol.Optional(CONF_CLEAR_TIMEOUT, default=DEFAULT_CLEAR_TIMEOUT): cv.positive_int,
     vol.Optional(
         CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
     ): cv.positive_int,
     vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
-    vol.Optional(CONF_NOTIFICATION_DEVICES, default=[]): cv.entity_ids,
-    vol.Optional(CONF_NOTIFY_ON_SLEEP, default=DEFAULT_NOTIFY_ON_SLEEP): bool,
-    vol.Optional(CONF_NIGHT_ENTITY): cv.entity_id,
-    vol.Optional(CONF_NIGHT_STATE, default=DEFAULT_NIGHT_STATE): str,
-    vol.Optional(CONF_SLEEP_ENTITY): cv.entity_id,
-    vol.Optional(CONF_SLEEP_STATE, default=DEFAULT_SLEEP_STATE): str,
-    vol.Optional(CONF_SLEEP_TIMEOUT, default=DEFAULT_SLEEP_TIMEOUT): cv.positive_int,
-    vol.Optional(CONF_MAIN_LIGHTS, default=[]): cv.entity_ids,
-    vol.Optional(CONF_SLEEP_LIGHTS, default=[]): cv.entity_ids,
-}
+})
 
-_DOMAIN_SCHEMA = vol.Schema({cv.slug: vol.Any(_AREA_SCHEMA, None)})
+AREA_SCHEMA = vol.Schema(vol.Any(REGULAR_AREA_SCHEMA, META_AREA_SCHEMA))
+
+_DOMAIN_SCHEMA = vol.Schema({cv.slug: vol.Any(AREA_SCHEMA, None)})
 # Autolights States
 AUTOLIGHTS_STATE_SLEEP = "sleep"
 AUTOLIGHTS_STATE_NORMAL = "enabled"
 AUTOLIGHTS_STATE_DISABLED = "disabled"
 
 # VALIDATION_TUPLES
-VALIDATION_TUPLES = [
-    (CONF_ENABLED_FEATURES, DEFAULT_ENABLED_FEATURES, cv.ensure_list),
+OPTIONS_AREA = [
+    (CONF_TYPE, DEFAULT_TYPE, vol.In([AREA_TYPE_INTERIOR, AREA_TYPE_EXTERIOR])),
     (CONF_INCLUDE_ENTITIES, [], cv.entity_ids),
     (CONF_EXCLUDE_ENTITIES, [], cv.entity_ids),
     (
@@ -251,31 +290,34 @@ VALIDATION_TUPLES = [
         DEFAULT_PRESENCE_DEVICE_SENSOR_CLASS,
         cv.ensure_list,
     ),
+    (CONF_ON_STATES, ",".join(DEFAULT_ON_STATES), str),  # this should actually be cv.ensure_list_csv, but voluptuous doesn't support serializing this validator, so we'll work around with str and mangling the default
     (CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT, int),
-    (CONF_ICON, DEFAULT_ICON, str),
-    (CONF_AGGREGATES_MIN_ENTITIES, DEFAULT_AGGREGATES_MIN_ENTITIES, int),
-    (CONF_NOTIFICATION_DEVICES, [], cv.entity_ids),
-    (CONF_NOTIFY_ON_SLEEP, DEFAULT_NOTIFY_ON_SLEEP, bool),
-    (CONF_NIGHT_ENTITY, "", cv.entity_id),
-    (CONF_NIGHT_STATE, DEFAULT_NIGHT_STATE, str),
-    (CONF_MAIN_LIGHTS, [], cv.entity_ids),
-    (CONF_SLEEP_LIGHTS, [], cv.entity_ids),
-    (
-        CONF_SLEEP_ENTITY,
-        "",
-        cv.entity_id,
-    ),
-    (CONF_SLEEP_STATE, DEFAULT_SLEEP_STATE, str),
     (CONF_SLEEP_TIMEOUT, DEFAULT_SLEEP_TIMEOUT, int),
     (CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, int),
-    (CONF_TYPE, DEFAULT_TYPE, str),
+    (CONF_ICON, DEFAULT_ICON, str),
 ]
 
-VALIDATION_TUPLES_META = [
-    (CONF_ENABLED_FEATURES, DEFAULT_ENABLED_FEATURES, cv.ensure_list),
+OPTIONS_AREA_META = [
     (CONF_EXCLUDE_ENTITIES, [], cv.entity_ids),
     (CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT, int),
-    (CONF_ICON, DEFAULT_ICON, str),
-    (CONF_AGGREGATES_MIN_ENTITIES, DEFAULT_AGGREGATES_MIN_ENTITIES, int),
     (CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, int),
+    (CONF_ICON, DEFAULT_ICON, str),
+]
+
+OPTIONS_LIGHT_GROUP = [
+    (CONF_MAIN_LIGHTS, [], cv.entity_ids),
+    (CONF_SLEEP_LIGHTS, [], cv.entity_ids),
+    (CONF_SLEEP_ENTITY, "", cv.entity_id),
+    (CONF_SLEEP_STATE, DEFAULT_SLEEP_STATE, str),
+    (CONF_NIGHT_ENTITY, "", cv.entity_id),
+    (CONF_NIGHT_STATE, DEFAULT_NIGHT_STATE, str),
+]
+
+OPTIONS_AGGREGATES = [
+    (CONF_AGGREGATES_MIN_ENTITIES, DEFAULT_AGGREGATES_MIN_ENTITIES, int),
+]
+
+OPTIONS_AREA_AWARE_MEDIA_PLAYER = [
+    (CONF_NOTIFICATION_DEVICES, [], cv.entity_ids),
+    (CONF_NOTIFY_ON_SLEEP, DEFAULT_NOTIFY_ON_SLEEP, bool),
 ]

--- a/custom_components/magic_areas/translations/en.json
+++ b/custom_components/magic_areas/translations/en.json
@@ -14,33 +14,66 @@
   },
   "options": {
     "step": {
-      "init": {
-        "title": "Magic Areas options",
-        "description": "All settings for a Magic Areas component. The option names correspond with the YAML settings. No options are shown if you have this entry defined in YAML.",
+      "select_features": {
+        "title": "Feature selection",
+        "description": "Select the features you want to enable for this area. Each feature will be configured in subsequent steps.",
         "data": {
-          "features": "Enabled features",
-          "include_entities": "Include entities to this area",
-          "exclude_entities": "Exclude entities from being analyzed",
-          "presence_sensor_device_class": "Device classes of sensors to be considered presence sensors",
-          "icon": "Icon",
-          "notification_devices": "Media Player devices used for broadcasting through Area-Aware Media Player",
-          "notify_on_sleep": "Allow notification devices in this area to play notifications when on sleep mode",
-          "update_interval": "Interval for checking missed events",
-          "clear_timeout": "How long since last presence event should it wait before clearing the area",
-          "aggregates_min_entities": "Minimum number of entities of the same device class required to create aggregates.",
+          "control_climate": "Control climate devices",
+          "control_lights": "Automatic lights",
+          "control_media": "Control media devices",
+          "light_groups": "Create light groups",
+          "cover_groups": "Create cover groups",
+          "area_aware_media_player": "Area aware media player",
+          "aggregates": "Create aggregate sensors",
+          "health": "Create health sensors"
+        }
+      },
+      "feature_conf_light_groups": {
+        "title": "Light Groups",
+        "description": "Configure the Light Groups feature",
+        "data": {
           "night_entity": "Entity used to track area night state",
           "night_state": "State of night entity",
           "sleep_entity": "Entity used to track area sleep state",
           "sleep_state": "State of sleep entity",
-          "sleep_timeout": "How long since last presence event should it wait before clearing the area when on sleep mode",
           "main_lights": "Main lights (Leave blank for all area lights)",
-          "sleep_lights": "Sleep lights",
+          "sleep_lights": "Sleep lights"
+        }
+      },
+      "feature_conf_area_aware_media_player": {
+        "title": "Feature: Area aware media player",
+        "description": "Configure the area aware media player feature",
+        "data": {
+          "notification_devices": "Media Player devices used for broadcasting",
+          "notify_on_sleep": "Allow notification devices in this area to play notifications when on sleep mode"
+        }
+      },
+      "feature_conf_aggregates": {
+        "title": "Feature: Sensor aggregates",
+        "description": "Configure the sensor aggregates feature",
+        "data": {
+          "aggregates_min_entities": "Minimum number of entities of the same device class required to create aggregates."
+        }
+      },
+      "area_config": {
+        "title": "Area options",
+        "description": "Configure basic options for the area.",
+        "data": {
+          "include_entities": "Include entities to this area",
+          "exclude_entities": "Exclude entities from being analyzed",
+          "presence_sensor_device_class": "Device classes of sensors to be considered presence sensors",
+          "on_states": "Sensor states that indicate presence",
+          "icon": "Icon",
+          "update_interval": "Interval for checking missed events",
+          "clear_timeout": "How long since last presence event should it wait before clearing the area",
+          "sleep_timeout": "How long since last presence event should it wait before clearing the area when on sleep mode",
           "type": "Area type (interior/exterior)"
         }
       }
     },
     "error": {
-      "option_error": "Invalid option"
+      "option_error": "Invalid option",
+      "malformed_input": "This field is invalid:"
     }
   }
 } 


### PR DESCRIPTION
This splits the configuration options flow up into multiple steps and should serve as a basis going forward, before incorporating more features (as discussed in my other PRs).

There's an initial step for setting general options on the area, followed by a "feature select" step. Depending on the selected features, and if the features provide additional configuration options, there are more steps to follow.

Because the validation schema in the background has changed, this breaks backwards compatibility. I might add migration logic for old config entries, but am not yet certain about that.