### PR TITLE
Event-based IPC

### DIFF
--- a/custom_components/magic_areas/light.py
+++ b/custom_components/magic_areas/light.py
@@ -6,9 +6,8 @@ from homeassistant.components.group.light import LightGroup
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 
 from .const import (
-    CONF_AGGREGATES_MIN_ENTITIES,
     CONF_FEATURE_LIGHT_GROUPS,
-    CONF_FEATURE_AGGREGATION,
+    LIGHT_GROUP_CATEGORIES,
     DATA_AREA_OBJECT,
     MODULE_DATA,
 )
@@ -32,16 +31,27 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         return
 
     light_entities = [e["entity_id"] for e in area.entities[LIGHT_DOMAIN]]
-    group_name = f"{area.name} Lights"
 
-    # Check CONF_AGGREGATES_MIN_ENTITIES
-    # @TODO add min_entities for the group instead of using from aggr
-    if len(light_entities) < area.feature_config(CONF_FEATURE_AGGREGATION).get(CONF_AGGREGATES_MIN_ENTITIES):
+    if not light_entities:
         _LOGGER.debug(f"Not enough entities for Light group for area {area.name}")
         return
 
-    # Create Light Group
+    light_groups = []
+
+    # Create All light group
     _LOGGER.debug(
-        f"Creating light groups for area {area.name} with lights: {light_entities}"
+        f"Creating Area light group for area {area.name} with lights: {light_entities}"
     )
-    async_add_entities([LightGroup(group_name, light_entities)])
+    light_groups.append(LightGroup(f"{area.name} Lights", light_entities))
+
+    # Create extended light groups
+    for category in LIGHT_GROUP_CATEGORIES:
+        category_lights = area.feature_config(CONF_FEATURE_LIGHT_GROUPS).get(category)
+
+        if category_lights:
+            category_title = ' '.join(category.split('_')).title()
+            _LOGGER.debug(f"Creating {category_title} group for area {area.name} with lights: {category_lights}")
+            light_groups.append(LightGroup(f"{category_title} ({area.name})", category_lights))
+
+    # Create all groups
+    async_add_entities(light_groups)


### PR DESCRIPTION
This PR is setting the base and adapting #101 to work under this new premise. Now `sleep` and `dark` are considered `secondary states` of an area (with some others coming). This allows those secondary states to be listened by other features and be effectively decoupled from the light group feature.

For the light group revamp (aka #101) the logic is mostly the same from @caphm but instead of one light group controlling the logic + ability to create subgroups, the different categories (accent, sleep, overhead) have their own light group (considered subgroup before) created if defined. 

For each category of lights, you can specify in which state it will react to (i.e. turn on). This allows each group to track it's states since all groups can listen to the area state changed event and call `area.has_state('xyz')` to check if they should turn on.

This will free up the area `binary_sensor` of a bunch of feature-related logic and allow the `climate control` feature to only turn on after the area is occupied by a set amount of time by listening to an `extended` secondary state.