### PR TITLE
Update LightGroup signature.

### DIFF
--- a/custom_components/magic_areas/light.py
+++ b/custom_components/magic_areas/light.py
@@ -42,4 +42,4 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
     _LOGGER.debug(
         f"Creating light groups for area {area.name} with lights: {light_entities}"
     )
-    async_add_entities([LightGroup(group_name, light_entities)])
+    async_add_entities([LightGroup(None, group_name, light_entities)])


### PR DESCRIPTION
Patches the signature of the created LightGroup objects such that light groups can be successfully created under HA 2021.8.0 and above. (Fixes #131 .)