### PR TITLE
Aggregate sensor device_class/unit of measure map key bug

### DIFF
--- a/custom_components/magic_areas/sensor.py
+++ b/custom_components/magic_areas/sensor.py
@@ -44,7 +44,7 @@ async def load_sensors(hass, async_add_entities, area):
     if not area.has_entities(SENSOR_DOMAIN):
         return
 
-    device_class_count = {}
+    device_class_uom_pairs = []
 
     for entity in area.entities[SENSOR_DOMAIN]:
 
@@ -60,19 +60,21 @@ async def load_sensors(hass, async_add_entities, area):
             )
             continue
 
-        map_key = f"{entity['device_class']}/{entity['unit_of_measurement']}"
-        if map_key not in device_class_count.keys():
-            device_class_count[map_key] = 0
+        device_class_uom_pairs.append(entity['device_class'], entity['unit_of_measurement'])
 
-        device_class_count[map_key] += 1
+    # Sort out individual pairs, if they show up more than CONF_AGGREGATES_MIN_ENTITIES,
+    # we create a sensor for them
+    unique_pairs = set(device_class_uom_pairs)
 
-    for map_key, entity_count in device_class_count.items():
+    for dc_uom_pair in unique_pairs:
+        entity_count = device_class_uom_pairs.count(dc_uom_pair)
+
         if entity_count < area.feature_config(CONF_FEATURE_AGGREGATION).get(
             CONF_AGGREGATES_MIN_ENTITIES
         ):
             continue
 
-        device_class, unit_of_measurement = map_key.split("/")
+        device_class, unit_of_measurement = dc_uom_pair
 
         _LOGGER.debug(
             f"Creating aggregate sensor for device_class '{device_class}' ({unit_of_measurement}) with {entity_count} entities ({area.slug})"


### PR DESCRIPTION
The function was logically flawed. I used a string made of `{device_class/unit_of_measurement}` for a dict key (used for lookup) and when faced with an unit of measurement that has `/`, ta-da! 

Changing to another character was another bug waiting to happen, so I rewrote it and now should work regardless of the values on those attributes.

This (probably) fixes https://github.com/jseidl/hass-magic_areas/issues/208. I can't test it tho because I don't have a sensor that fits this case.