### PR TITLE
removed integration name from unique ids bc is bad practice

### DIFF
--- a/custom_components/magic_areas/base.py
+++ b/custom_components/magic_areas/base.py
@@ -55,7 +55,7 @@ class MagicEntity:
     def unique_id(self):
         """Return a unique ID."""
         name_slug = slugify(self._name)
-        return f"magic_areas_entity_{name_slug}"
+        return f"entity_{name_slug}"
 
     @property
     def name(self):

--- a/custom_components/magic_areas/cover.py
+++ b/custom_components/magic_areas/cover.py
@@ -65,9 +65,9 @@ class AreaCoverGroup(MagicEntity, CoverGroup):
         self._attributes["covers"] = [e["entity_id"] for e in self._entities]
 
         unique_id = (
-            f"magicareas_cover_group_{area.slug}_{device_class}"
+            f"cover_group_{area.slug}_{device_class}"
             if device_class
-            else f"magicareas_cover_group_{area.slug}"
+            else f"cover_group_{area.slug}"
         )
 
         CoverGroup.__init__(self, unique_id, self._name, self._attributes["covers"])

--- a/custom_components/magic_areas/light.py
+++ b/custom_components/magic_areas/light.py
@@ -62,7 +62,7 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         f"Creating Area light group for area {area.name} with lights: {light_entities}"
     )
     if area.is_meta():
-        unique_id = f"magicareas_light_group_meta_{area.slug}_all"
+        unique_id = f"light_group_meta_{area.slug}_all"
         light_groups.append(
             LightGroup(unique_id, f"{area.name} Lights", light_entities, mode=False)
         )
@@ -108,9 +108,9 @@ class AreaLightGroup(MagicEntity, LightGroup, RestoreEntity):
         self._attributes = {} # clear object
 
         unique_id = (
-            f"magicareas_light_group_{area.slug}_{category}"
+            f"light_group_{area.slug}_{category}"
             if category
-            else f"magicareas_light_group_{area.slug}_all"
+            else f"light_group_{area.slug}_all"
         )
 
         LightGroup.__init__(self, unique_id, self._name, self._entities, mode=False)

--- a/custom_components/magic_areas/media_player.py
+++ b/custom_components/magic_areas/media_player.py
@@ -290,7 +290,7 @@ class AreaMediaPlayerGroup(MagicEntity, MediaPlayerGroup):
         self.hass = hass
         self.area = area
 
-        unique_id = f"magicareas_media_player_group_{area.slug}"
+        unique_id = f"media_player_group_{area.slug}"
 
         MediaPlayerGroup.__init__(self, unique_id, self._name, self._entities)
 


### PR DESCRIPTION
According to unique_id documentation, integration name should be omitted as it's automatically handled.