### PR TITLE
Fix Iterable import on util.py

### DIFF
--- a/custom_components/magic_areas/util.py
+++ b/custom_components/magic_areas/util.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 basestring = (str, bytes)
 


### PR DESCRIPTION
Python 3.10 (Home Assistant current as of 2022.7 release) moved Iterable from `collections` into `collections.abc`. Fixed the import on `util.py`.