### PR TITLE
fixing defaults and optionals on selectors for config flow

### DIFF
--- a/custom_components/magic_areas/base.py
+++ b/custom_components/magic_areas/base.py
@@ -662,7 +662,9 @@ class MagicMetaArea(MagicArea):
                             continue
 
                         # Skip excluded entities
-                        if entity["entity_id"] in self.config.get(CONF_EXCLUDE_ENTITIES):
+                        if entity["entity_id"] in self.config.get(
+                            CONF_EXCLUDE_ENTITIES
+                        ):
                             continue
 
                         entity_list.append(entity["entity_id"])

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -8,7 +8,11 @@ from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
-from homeassistant.helpers.selector import selector, EntitySelector, EntitySelectorConfig
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    selector,
+)
 
 from custom_components.magic_areas.const import (
     ALL_BINARY_SENSOR_DEVICE_CLASSES,
@@ -104,6 +108,18 @@ class NullableEntitySelector(EntitySelector):
 
         return super().__call__(data)
 
+class NullableEntitySelector(EntitySelector):
+    def __call__(self, data):
+        """Validate the passed selection, if passed."""
+
+        _LOGGER.warn(f"Null data {data}")
+
+        if not data:
+            return data
+
+        return super().__call__(data)
+
+
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Magic Areas."""
 
@@ -170,11 +186,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         # return selector(selector_opts)
 
         return NullableEntitySelector(
-            EntitySelectorConfig(
-                include_entities=options,
-                multiple=multiple
-                )
-            )
+            EntitySelectorConfig(include_entities=options, multiple=multiple)
+        )
 
     def _build_selector_number(
         self, min=0, max=9999, mode="box", unit_of_measurement="seconds"
@@ -210,8 +223,10 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
             vol.Optional(
                 name,
                 description={"suggested_value": saved_options.get(name)},
-                default=default
-            ): selectors[name] if name in selectors.keys() else dynamic_validators.get(name, validation)
+                default=default,
+            ): selectors[name]
+            if name in selectors.keys()
+            else dynamic_validators.get(name, validation)
             for name, default, validation in options
         }
 
@@ -315,8 +330,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 sorted([AREA_TYPE_INTERIOR, AREA_TYPE_EXTERIOR])
             ),
             CONF_INCLUDE_ENTITIES: self._build_selector_entity_simple(
-                self.all_entities,
-                multiple=True
+                self.all_entities, multiple=True
             ),
             CONF_EXCLUDE_ENTITIES: self._build_selector_entity_simple(
                 self.all_area_entities, multiple=True

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -97,16 +97,6 @@ _LOGGER = logging.getLogger(__name__)
 EMPTY_ENTRY = [""]
 
 class NullableEntitySelector(EntitySelector):
-
-    def __call__(self, data):
-        """Validate the passed selection, if passed."""
-
-        if not data:
-            return data
-
-        return super().__call__(data)
-
-class NullableEntitySelector(EntitySelector):
     def __call__(self, data):
         """Validate the passed selection, if passed."""
 
@@ -116,7 +106,6 @@ class NullableEntitySelector(EntitySelector):
             return data
 
         return super().__call__(data)
-
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Magic Areas."""

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -101,8 +101,6 @@ class NullableEntitySelector(EntitySelector):
     def __call__(self, data):
         """Validate the passed selection, if passed."""
 
-        _LOGGER.warn(f"Null data {data}")
-
         if not data:
             return data
 
@@ -177,13 +175,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
     def _build_selector_entity_simple(
         self, options=[], multiple=False, force_include=False
     ):
-
-        # selector_opts = {"entity": {"multiple": multiple}}
-
-        # if options is not None:
-        #     selector_opts["entity"]["include_entities"] = options
-
-        # return selector(selector_opts)
 
         return NullableEntitySelector(
             EntitySelectorConfig(include_entities=options, multiple=multiple)

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -202,7 +202,7 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         schema = {
             vol.Optional(
                 name,
-                description={"suggested_value": saved_options.get(name)},
+                description={"suggested_value": saved_options.get(name) if saved_options.get(name) else default},
                 default=default,
             ): selectors[name]
             if name in selectors.keys()

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -96,6 +96,7 @@ _LOGGER = logging.getLogger(__name__)
 
 EMPTY_ENTRY = [""]
 
+
 class NullableEntitySelector(EntitySelector):
     def __call__(self, data):
         """Validate the passed selection, if passed."""
@@ -106,6 +107,7 @@ class NullableEntitySelector(EntitySelector):
             return data
 
         return super().__call__(data)
+
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Magic Areas."""
@@ -202,7 +204,11 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         schema = {
             vol.Optional(
                 name,
-                description={"suggested_value": saved_options.get(name) if saved_options.get(name) else default},
+                description={
+                    "suggested_value": saved_options.get(name)
+                    if saved_options.get(name)
+                    else default
+                },
                 default=default,
             ): selectors[name]
             if name in selectors.keys()
@@ -378,9 +384,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     CONF_ACCENT_ENTITY: vol.In(EMPTY_ENTRY + self.all_entities),
                 },
                 selectors={
-                    # CONF_DARK_ENTITY: self._build_selector_entity_simple(),
-                    # CONF_SLEEP_ENTITY: self._build_selector_entity_simple(),
-                    # CONF_ACCENT_ENTITY: self._build_selector_entity_simple(),
                     CONF_DARK_ENTITY: self._build_selector_entity_simple(
                         self.all_entities
                     ),


### PR DESCRIPTION
Fix for #236. Reworked selectors slightly. Original implementation of selectors in Magic Areas was not very well implemented by me and was ignoring defaults and optionals.

In fact, the `EntitySelectors` does not support blank values at all so I had to create a new class extending it and checking if the value is null on validation and just allowing it. Seems to be working fine now.