### PR TITLE
Update __init__.py to fix #265

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -65,7 +65,7 @@ async def async_setup(hass, config):
         _LOGGER.debug(f"Appending Meta Area {meta_area} to the list of areas")
         areas.append(
             AreaEntry(
-                name=meta_area, normalized_name=meta_area.lower(), id=meta_area.lower()
+                name=meta_area, normalized_name=meta_area.lower(), aliases=set(), id=meta_area.lower()
             )
         )
 


### PR DESCRIPTION
This just solves the immediate error in #265; it doesn't actually use the new aliases parameter for anything, but it does let Magic Areas run normally.
