### PR TITLE
Replacing the deprecated DEVICE_CLASS_ variables

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -65,7 +65,10 @@ async def async_setup(hass, config):
         _LOGGER.debug(f"Appending Meta Area {meta_area} to the list of areas")
         areas.append(
             AreaEntry(
-                name=meta_area, normalized_name=meta_area.lower(), aliases=set(), id=meta_area.lower()
+                name=meta_area,
+                normalized_name=meta_area.lower(),
+                aliases=set(),
+                id=meta_area.lower(),
             )
         )
 

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -3,11 +3,6 @@ DEPENDENCIES = ["magic_areas", "media_player", "binary_sensor"]
 import logging
 from datetime import datetime, timedelta
 
-<<<<<<< HEAD
-from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-
-=======
->>>>>>> 2fd522ad8de4b0598f63a6975780973bac4ef7f5
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -3,9 +3,13 @@ DEPENDENCIES = ["magic_areas", "media_player", "binary_sensor"]
 import logging
 from datetime import datetime, timedelta
 
+<<<<<<< HEAD
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 
+=======
+>>>>>>> 2fd522ad8de4b0598f63a6975780973bac4ef7f5
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -3,10 +3,8 @@ DEPENDENCIES = ["magic_areas", "media_player", "binary_sensor"]
 import logging
 from datetime import datetime, timedelta
 
-from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_OCCUPANCY,
-    DEVICE_CLASS_PROBLEM,
-)
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
@@ -170,7 +168,7 @@ class AreaPresenceBinarySensor(BinarySensorBase):
         self.last_off_time = datetime.utcnow()
         self.clear_timeout_callback = None
 
-        self._device_class = DEVICE_CLASS_OCCUPANCY
+        self._device_class = BinarySensorDeviceClass.OCCUPANCY
         self.sensors = []
 
     def load_presence_sensors(self) -> None:
@@ -607,7 +605,7 @@ class AreaDistressBinarySensor(BinarySensorBase, AggregateBase):
 
         self.area = area
         self.hass = hass
-        self._device_class = DEVICE_CLASS_PROBLEM
+        self._device_class = BinarySensorDeviceClass.PROBLEM
         self._state = False
 
         self._name = f"Area Health ({self.area.name})"

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -38,7 +38,7 @@ EVENT_MAGICAREAS_AREA_OCCUPIED = "magicareas_area_occupied"
 EVENT_MAGICAREAS_AREA_CLEAR = "magicareas_area_clear"
 EVENT_MAGICAREAS_AREA_STATE_CHANGED = "magicareas_area_state_changed"
 
-ALL_BINARY_SENSOR_DEVICE_CLASSES = [cls.value for cls in SensorDeviceClass]
+ALL_BINARY_SENSOR_DEVICE_CLASSES = [cls.value for cls in BinarySensorDeviceClass]
 
 # Data Items
 DATA_AREA_OBJECT = "area_object"

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -1,19 +1,16 @@
 from itertools import chain
 
 import voluptuous as vol
-
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
-
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
-from homeassistant.components.sensor import SensorDeviceClass
-
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
@@ -301,7 +298,15 @@ AGGREGATE_SENSOR_CLASSES = (
     SensorDeviceClass.TEMPERATURE,
 )
 
+<<<<<<< HEAD
 AGGREGATE_MODE_SUM = [SensorDeviceClass.POWER, SensorDeviceClass.CURRENT, SensorDeviceClass.ENERGY]
+=======
+AGGREGATE_MODE_SUM = [
+    SensorDeviceClass.POWER,
+    SensorDeviceClass.CURRENT,
+    SensorDeviceClass.ENERGY,
+]
+>>>>>>> 2fd522ad8de4b0598f63a6975780973bac4ef7f5
 
 # Config Schema
 

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -1,36 +1,21 @@
 from itertools import chain
 
 import voluptuous as vol
-from homeassistant.components.binary_sensor import (
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_GAS,
-    DEVICE_CLASS_LIGHT,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_OCCUPANCY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_PRESENCE,
-    DEVICE_CLASS_PROBLEM,
-    DEVICE_CLASS_SAFETY,
-    DEVICE_CLASS_SMOKE,
-    DEVICE_CLASS_WINDOW,
-    DEVICE_CLASSES,
-)
+
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.sensor import SensorDeviceClass
+
 from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
-from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_TEMPERATURE,
     STATE_ALARM_TRIGGERED,
     STATE_HOME,
     STATE_ON,
@@ -53,9 +38,7 @@ EVENT_MAGICAREAS_AREA_OCCUPIED = "magicareas_area_occupied"
 EVENT_MAGICAREAS_AREA_CLEAR = "magicareas_area_clear"
 EVENT_MAGICAREAS_AREA_STATE_CHANGED = "magicareas_area_state_changed"
 
-DEVICE_CLASS_DOMAINS = (BINARY_SENSOR_DOMAIN, SENSOR_DOMAIN)
-
-ALL_BINARY_SENSOR_DEVICE_CLASSES = DEVICE_CLASSES
+ALL_BINARY_SENSOR_DEVICE_CLASSES = [cls.value for cls in SensorDeviceClass]
 
 # Data Items
 DATA_AREA_OBJECT = "area_object"
@@ -153,9 +136,9 @@ ALL_PRESENCE_DEVICE_PLATFORMS = [
     CONF_PRESENCE_SENSOR_DEVICE_CLASS,
     DEFAULT_PRESENCE_DEVICE_SENSOR_CLASS,
 ) = "presence_sensor_device_class", [
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_OCCUPANCY,
-    DEVICE_CLASS_PRESENCE,
+    BinarySensorDeviceClass.MOTION,
+    BinarySensorDeviceClass.OCCUPANCY,
+    BinarySensorDeviceClass.PRESENCE,
 ]  # cv.ensure_list
 CONF_ON_STATES, DEFAULT_ON_STATES = "on_states", [
     STATE_ON,
@@ -291,34 +274,34 @@ LIGHT_GROUP_CATEGORIES = [
 ]
 
 AGGREGATE_BINARY_SENSOR_CLASSES = [
-    DEVICE_CLASS_WINDOW,
-    DEVICE_CLASS_DOOR,
-    DEVICE_CLASS_MOTION,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_LIGHT,
+    BinarySensorDeviceClass.WINDOW,
+    BinarySensorDeviceClass.DOOR,
+    BinarySensorDeviceClass.MOTION,
+    BinarySensorDeviceClass.MOISTURE,
+    BinarySensorDeviceClass.LIGHT,
 ]
 
 # Health related
 DISTRESS_SENSOR_CLASSES = [
-    DEVICE_CLASS_PROBLEM,
-    DEVICE_CLASS_SMOKE,
-    DEVICE_CLASS_MOISTURE,
-    DEVICE_CLASS_SAFETY,
-    DEVICE_CLASS_GAS,
+    BinarySensorDeviceClass.PROBLEM,
+    BinarySensorDeviceClass.SMOKE,
+    BinarySensorDeviceClass.MOISTURE,
+    BinarySensorDeviceClass.SAFETY,
+    BinarySensorDeviceClass.GAS,
 ]  # @todo make configurable
 DISTRESS_STATES = [STATE_ALARM_TRIGGERED, STATE_ON, STATE_PROBLEM]
 
 # Aggregates
 AGGREGATE_SENSOR_CLASSES = (
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_HUMIDITY,
-    DEVICE_CLASS_ILLUMINANCE,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_TEMPERATURE,
+    SensorDeviceClass.CURRENT,
+    SensorDeviceClass.ENERGY,
+    SensorDeviceClass.HUMIDITY,
+    SensorDeviceClass.ILLUMINANCE,
+    SensorDeviceClass.POWER,
+    SensorDeviceClass.TEMPERATURE,
 )
 
-AGGREGATE_MODE_SUM = [DEVICE_CLASS_POWER, DEVICE_CLASS_CURRENT, DEVICE_CLASS_ENERGY]
+AGGREGATE_MODE_SUM = [SensorDeviceClass.POWER, SensorDeviceClass.CURRENT, SensorDeviceClass.ENERGY]
 
 # Config Schema
 

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -298,15 +298,11 @@ AGGREGATE_SENSOR_CLASSES = (
     SensorDeviceClass.TEMPERATURE,
 )
 
-<<<<<<< HEAD
-AGGREGATE_MODE_SUM = [SensorDeviceClass.POWER, SensorDeviceClass.CURRENT, SensorDeviceClass.ENERGY]
-=======
 AGGREGATE_MODE_SUM = [
     SensorDeviceClass.POWER,
     SensorDeviceClass.CURRENT,
     SensorDeviceClass.ENERGY,
 ]
->>>>>>> 2fd522ad8de4b0598f63a6975780973bac4ef7f5
 
 # Config Schema
 


### PR DESCRIPTION
This closes #266 by replacing the `DEVICE_CLASS_*` variables with the new `(Binary)SensorDeviceClass` enums. 