### PR TITLE
Adding SUN_DOMAIN (sun.sun) to the config flow entity filter

### DIFF
--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -11,6 +11,7 @@ from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
 from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sun import DOMAIN as SUN_DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     STATE_ALARM_TRIGGERED,
@@ -555,4 +556,5 @@ CONFIG_FLOW_ENTITY_FILTER_EXT = CONFIG_FLOW_ENTITY_FILTER + [
     LIGHT_DOMAIN,
     MEDIA_PLAYER_DOMAIN,
     CLIMATE_DOMAIN,
+    SUN_DOMAIN,
 ]


### PR DESCRIPTION
Closes #256. Replacing #272 as it got in conflict and needed one more line.