### PR TITLE
Fixing version number on release drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-name-template: v$NEXT_PATCH_VERSION
-tag-template: v$NEXT_PATCH_VERSION
+name-template: $NEXT_PATCH_VERSION
+tag-template: $NEXT_PATCH_VERSION
 categories:
   - title: 🚀 Features
     labels:


### PR DESCRIPTION
I don't like the `v` in front of the versions, lets just do straight version numbers