### PR TITLE
Checking if area was just occupied when bright before turning off

### DIFF
--- a/custom_components/magic_areas/light.py
+++ b/custom_components/magic_areas/light.py
@@ -241,7 +241,8 @@ class AreaLightGroup(LightGroup, MagicEntity):
             return False
 
         if self.area.has_state(AREA_STATE_BRIGHT):
-            if AREA_STATE_BRIGHT in new_states:
+            # Only turn off lights when bright if the room was already occupied
+            if AREA_STATE_BRIGHT in new_states and AREA_STATE_OCCUPIED not in new_states:
                 self.controlled = True
                 self._turn_off()
             return False


### PR DESCRIPTION
Closes https://github.com/jseidl/hass-magic_areas/issues/258. Magic Areas will no longer turn lights off if you enter a bright room with lights already on. Will still turn lights off if the room was already occupied and becomes bright.