### PR TITLE
Adding support for binary sensors to act in ALL mode 

### DIFF
--- a/custom_components/magic_areas/base/entities.py
+++ b/custom_components/magic_areas/base/entities.py
@@ -106,6 +106,7 @@ class MagicBinarySensorEntity(MagicEntity, BinarySensorEntity):
     
     last_off_time = None
     _state = False
+    _mode = "single"
 
     def __init__(self, area, device_class):
 
@@ -186,7 +187,10 @@ class MagicBinarySensorEntity(MagicEntity, BinarySensorEntity):
             self.logger.debug("[Area: {self.area.slug}] Active areas: {active_areas}")
             self._attributes["active_areas"] = active_areas
 
-        return len(active_sensors) > 0
+        if self._mode == 'all':
+            return (len(active_sensors) == len(self.sensors))
+        else:
+            return len(active_sensors) > 0
 
 class MagicSensorEntity(MagicEntity, SensorEntity):
     _mode = "mean"

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -58,6 +58,7 @@ from custom_components.magic_areas.const import (
     DISTRESS_SENSOR_CLASSES,
     EVENT_MAGICAREAS_AREA_STATE_CHANGED,
     INVALID_STATES,
+    AGGREGATE_MODE_ALL,
 )
 from custom_components.magic_areas.util import add_entities_when_ready
 
@@ -549,6 +550,8 @@ class AreaSensorGroupBinarySensor(BinarySensorGroupBase):
         """Initialize an area sensor group binary sensor."""
 
         super().__init__(area, device_class)
+
+        self._mode = "all" if device_class in AGGREGATE_MODE_ALL else "single"
 
         device_class_name = " ".join(device_class.split("_")).title()
         self._name = f"Area {device_class_name} ({self.area.name})"

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -281,6 +281,11 @@ AGGREGATE_BINARY_SENSOR_CLASSES = [
     BinarySensorDeviceClass.LIGHT,
 ]
 
+AGGREGATE_MODE_ALL = [
+    BinarySensorDeviceClass.CONNECTIVITY,
+    BinarySensorDeviceClass.PLUG,
+]
+
 # Health related
 DISTRESS_SENSOR_CLASSES = [
     BinarySensorDeviceClass.PROBLEM,


### PR DESCRIPTION
For sensors that make sense to report ON only if all entities are ON (e.g. connectivity, plug), Magic Areas does that like we have for sensors mean/sum.

Closes #271 