### PR TITLE
Fixed CI pipeline now that ha-blueprint is deprecated

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,13 +4,11 @@ name: "Draft Release"
 on:
   push:
     branches:
-      - "develop"
+      - "main"
 
 jobs:
   update_release_draft:
-
     runs-on: ubuntu-latest
-
     steps:
       - uses: release-drafter/release-drafter@v5
         env:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,13 +1,7 @@
 name: "Validation Pipeline"
 on:
   push:
-    branches:
-      - 'hotfix/**'
-      - 'feature/**'
-      - 'release/**'
   pull_request:
-    branches: 
-      - main
   schedule:
     - cron: '0 0 * * *'
 jobs:

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -1,4 +1,4 @@
-name: "Validation And Formatting"
+name: "Validation Pipeline"
 on:
   push:
     branches:
@@ -7,21 +7,20 @@ on:
       - 'release/**'
   pull_request:
     branches: 
-      - master
-      - develop
+      - main
   schedule:
     - cron: '0 0 * * *'
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-        name: Download repo
+      - uses: actions/checkout@v3
+        name: Download repository
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v3
         name: Setup Python
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         name: Cache
         with:
           path: |
@@ -31,7 +30,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CATEGORY: integration
-      - uses: KTibow/ha-blueprint@stable
-        name: CI
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: home-assistant/actions/hassfest@master
+        name: Hassfest


### PR DESCRIPTION
Also changing to ReleaseFlow had to change out from the develop branch listeners to main branch listeners on the definition file.