### PR TITLE
Adding last_active_sensors to better help debug flipping sensors

### DIFF
--- a/custom_components/magic_areas/base/entities.py
+++ b/custom_components/magic_areas/base/entities.py
@@ -181,6 +181,10 @@ class MagicBinarySensorEntity(MagicEntity, BinarySensorEntity):
 
         self._attributes["active_sensors"] = active_sensors
 
+        # Make a copy that doesn't gets cleared out, for debugging
+        if active_sensors:
+            self._attributes["last_active_sensors"] = active_sensors
+
         self.logger.debug(f"[Area: {self.area.slug}] Active sensors: {active_sensors}")
 
         if self.area.is_meta():

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -26,6 +26,7 @@ from custom_components.magic_areas.const import (
     AREA_STATE_SLEEP,
     ATTR_ACTIVE_AREAS,
     ATTR_ACTIVE_SENSORS,
+    ATTR_LAST_ACTIVE_SENSORS,
     ATTR_AREAS,
     ATTR_CLEAR_TIMEOUT,
     ATTR_FEATURES,
@@ -276,34 +277,25 @@ class AreaPresenceBinarySensor(BinarySensorBase):
 
     def load_attributes(self) -> None:
         # Set attributes
-        self._attributes = {
-            ATTR_PRESENCE_SENSORS: self.sensors,
-            ATTR_FEATURES: [
-                feature_name
-                for feature_name, opts in self.area.config.get(
-                    CONF_ENABLED_FEATURES, {}
-                ).items()
-            ],
-            ATTR_ACTIVE_SENSORS: [],
-            ATTR_CLEAR_TIMEOUT: self.area.config.get(CONF_CLEAR_TIMEOUT),
-            ATTR_UPDATE_INTERVAL: self.area.config.get(CONF_UPDATE_INTERVAL),
-            ATTR_TYPE: self.area.config.get(CONF_TYPE),
-        }
+        self._attributes = {}
 
-        if self.area.is_meta():
+        if not self.area.is_meta():
+            self._attributes.update({ATTR_STATES: self.get_area_states()})
+        else:
             self._attributes.update(
                 {
                     ATTR_AREAS: self.area.get_child_areas(),
                     ATTR_ACTIVE_AREAS: self.area.get_active_areas(),
                 }
             )
-            return
 
-        # Add non-meta attributes
+        # Add common attributes
         self._attributes.update(
             {
-                ATTR_ON_STATES: self.area.config.get(CONF_ON_STATES),
-                ATTR_STATES: self.get_area_states(),
+                ATTR_ACTIVE_SENSORS: [],
+                ATTR_LAST_ACTIVE_SENSORS: [],
+                ATTR_PRESENCE_SENSORS: self.sensors,
+                ATTR_TYPE: self.area.config.get(CONF_TYPE),
             }
         )
 

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -51,6 +51,7 @@ ATTR_TYPE = "type"
 ATTR_UPDATE_INTERVAL = "update_interval"
 ATTR_CLEAR_TIMEOUT = "clear_timeout"
 ATTR_ACTIVE_SENSORS = "active_sensors"
+ATTR_LAST_ACTIVE_SENSORS = "last_active_sensors"
 ATTR_FEATURES = "features"
 ATTR_PRESENCE_SENSORS = "presence_sensors"
 


### PR DESCRIPTION
Sensors that are suffering from interference or other form of false-positives may hold an area active incorrectly but when you go check the `active_sensors` attribute, it's gone. Fear no longer with this new attribute called `last_active_sensors` that never gets cleared!