### PR TITLE
Generalizing Meta area object creation so we can centralize fixes 

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -4,9 +4,9 @@ from collections import defaultdict
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.area_registry import AreaEntry
 
 from custom_components.magic_areas.base.magic import MagicArea, MagicMetaArea
+from custom_components.magic_areas.util import get_meta_area_object
 from custom_components.magic_areas.const import (
     CONF_ID,
     CONF_NAME,
@@ -48,14 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
             config_entry,
         )
     else:
-        meta_area = AreaEntry(
-            name=area_name,
-            normalized_name=area_id,
-            aliases=set(),
-            id=area_id,
-            picture=None,
-            icon=None,
-        )
+        meta_area = get_meta_area_object(area_name)
         magic_area = MagicMetaArea(hass, meta_area, config_entry)
 
     _LOGGER.debug(

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
-from homeassistant.helpers.area_registry import AreaEntry
+
 from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers.selector import (
@@ -13,7 +13,7 @@ from homeassistant.helpers.selector import (
     EntitySelectorConfig,
     selector,
 )
-
+from custom_components.magic_areas.util import get_meta_area_object
 from custom_components.magic_areas.const import (
     _DOMAIN_SCHEMA,
     ALL_BINARY_SENSOR_DEVICE_CLASSES,
@@ -200,14 +200,7 @@ class ConfigFlow(config_entries.ConfigFlow, ConfigBase, domain=DOMAIN):
                 continue
 
             _LOGGER.debug(f"Appending Meta Area {meta_area} to the list of areas")
-            areas.append(
-                AreaEntry(
-                    name=meta_area,
-                    normalized_name=meta_area.lower(),
-                    aliases=set(),
-                    id=meta_area.lower(),
-                )
-            )
+            areas.append(get_meta_area_object(meta_area))
 
         if user_input is not None:
             

--- a/custom_components/magic_areas/util.py
+++ b/custom_components/magic_areas/util.py
@@ -1,6 +1,9 @@
 import logging
 from collections.abc import Iterable
 
+from homeassistant.helpers.area_registry import AreaEntry
+from homeassistant.util import slugify
+
 from custom_components.magic_areas.const import (
     MODULE_DATA,
     DATA_AREA_OBJECT,
@@ -71,4 +74,15 @@ def add_entities_when_ready(hass, async_add_entities, config_entry, callback_fn)
         # These sensors need to wait for the area object to be fully initialized
         callback = hass.bus.async_listen(
             EVENT_MAGICAREAS_AREA_READY, load_entities
+        )
+
+def get_meta_area_object(name):
+    
+    return AreaEntry(
+            name=name,
+            normalized_name=slugify(name),
+            aliases=set(),
+            id=slugify(name),
+            picture=None,
+            icon=None,
         )


### PR DESCRIPTION
Fixed all places that use `AreaEntry`.

Closes #312 