### PR TITLE
Adding Area default values for parameters that will be required in future versions

### DIFF
--- a/custom_components/magic_areas/util.py
+++ b/custom_components/magic_areas/util.py
@@ -1,4 +1,5 @@
 import logging
+import inspect
 from collections.abc import Iterable
 
 from homeassistant.helpers.area_registry import AreaEntry
@@ -80,13 +81,28 @@ def get_meta_area_object(name):
     
     area_slug = slugify(name) 
 
-    return AreaEntry(
-            name=name,
-            normalized_name=area_slug,
-            aliases=set(),
-            id=area_slug,
-            picture=None,
-            icon=None,
-            floor_id=None,
-            labels=set()
-        )
+    params = {
+        'name': name,
+        'normalized_name': area_slug,
+        'aliases': set(),
+        'id': area_slug,
+        'picture': None,
+        'icon': None,
+        'floor_id': None,
+        'labels': set()
+    }
+
+    # We have to introspect the AreaEntry constructor
+    # to know if a given param is available because usually
+    # Home Assistant updates this object with new parameters in
+    # the constructor without defaults and breaks this function
+    # in particular.
+
+    available_params = {}
+    constructor_params = inspect.signature(AreaEntry.__init__).parameters
+
+    for k, v in params.items():
+        if k in constructor_params:
+            available_params[k] = v
+
+    return AreaEntry(**available_params)

--- a/custom_components/magic_areas/util.py
+++ b/custom_components/magic_areas/util.py
@@ -78,13 +78,15 @@ def add_entities_when_ready(hass, async_add_entities, config_entry, callback_fn)
 
 def get_meta_area_object(name):
     
+    area_slug = slugify(name) 
+
     return AreaEntry(
             name=name,
-            normalized_name=slugify(name),
+            normalized_name=area_slug,
             aliases=set(),
-            id=slugify(name),
+            id=area_slug,
             picture=None,
             icon=None,
             floor_id=None,
-            label=None
+            labels=set()
         )

--- a/custom_components/magic_areas/util.py
+++ b/custom_components/magic_areas/util.py
@@ -85,4 +85,6 @@ def get_meta_area_object(name):
             id=slugify(name),
             picture=None,
             icon=None,
+            floor_id=None,
+            label=None
         )


### PR DESCRIPTION
Magic Areas create area objects for the meta areas so the MagicArea class accepts a single type. Whenever HA adds more parameters to the Area object, it breaks us. 

Fortunately @tbrasser is using the beta branch which helps us figure out when those changes happen. 

Added the `labels` and `floor_id` items with default values which should last for a while.