### PR TITLE
Update magic.py to use the async_get directly

### DIFF
--- a/custom_components/magic_areas/__init__.py
+++ b/custom_components/magic_areas/__init__.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.area_registry import async_get as async_get_ar
 
 from custom_components.magic_areas.base.magic import MagicArea, MagicMetaArea
 from custom_components.magic_areas.util import get_meta_area_object
@@ -33,7 +34,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     meta_ids = [meta_area.lower() for meta_area in META_AREAS]
 
     if area_id not in meta_ids:
-        area_registry = hass.helpers.area_registry.async_get(hass)
+        area_registry = async_get_ar(hass)
         area = area_registry.async_get_area(area_id)
 
         if not area:

--- a/custom_components/magic_areas/base/magic.py
+++ b/custom_components/magic_areas/base/magic.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, STATE_ON
 from homeassistant.util import slugify
 from homeassistant.helpers.discovery import async_load_platform
+from homeassistant.helpers.entity_registry import async_get as async_get_er
+from homeassistant.helpers.device_registry import async_get as async_get_dr
 
 from custom_components.magic_areas.util import flatten_entity_list, is_entity_list, areas_loaded
 from custom_components.magic_areas.const import (
@@ -158,7 +160,7 @@ class MagicArea(object):
         # Ignore our own entities
         if entity_object.device_id:
 
-            device_registry = self.hass.helpers.device_registry.async_get(self.hass)
+            device_registry = async_get_dr(self.hass)
             device_object = device_registry.async_get(entity_object.device_id)
 
             if device_object:
@@ -184,7 +186,7 @@ class MagicArea(object):
 
         # Check device's area id, if available
         if entity_object.device_id:
-            device_registry = self.hass.helpers.device_registry.async_get(self.hass)
+            device_registry = async_get_dr(self.hass)
             if entity_object.device_id in device_registry.devices.keys():
                 device_object = device_registry.devices[entity_object.device_id]
                 if device_object.area_id == self.id:
@@ -200,7 +202,7 @@ class MagicArea(object):
         entity_list = []
         include_entities = self.config.get(CONF_INCLUDE_ENTITIES)
 
-        entity_registry = self.hass.helpers.entity_registry.async_get(self.hass)
+        entity_registry = async_get_er(self.hass)
 
         for entity_id, entity_object in entity_registry.entities.items():
             # Check entity validity


### PR DESCRIPTION
Update the system to async_get_dr now that the main pieces have been deprecated in home assistant.  Removes warning in the logs.