### PR TITLE
Use area icon instead of configuration value

### DIFF
--- a/custom_components/magic_areas/base/magic.py
+++ b/custom_components/magic_areas/base/magic.py
@@ -52,6 +52,7 @@ class MagicArea:
         self.hass = hass
         self.name = area.name
         self.id = area.id
+        self.icon = area.icon
         self.slug = slugify(self.name)
         self.hass_config = config
         self.initialized = False

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -40,7 +40,6 @@ from .const import (
     CONF_FEATURE_AGGREGATION,
     CONF_FEATURE_HEALTH,
     CONF_FEATURE_PRESENCE_HOLD,
-    CONF_ICON,
     CONF_ON_STATES,
     CONF_PRESENCE_DEVICE_PLATFORMS,
     CONF_PRESENCE_SENSOR_DEVICE_CLASS,
@@ -166,9 +165,7 @@ class AreaPresenceBinarySensor(BinarySensorBase):
     @property
     def icon(self):
         """Return the icon to be used for this entity."""
-        if self.area.config.get(CONF_ICON):
-            return self.area.config.get(CONF_ICON)
-        return None
+        return self.area.icon
 
     @property
     def is_on(self):

--- a/custom_components/magic_areas/binary_sensor.py
+++ b/custom_components/magic_areas/binary_sensor.py
@@ -55,6 +55,8 @@ from .const import (
     DISTRESS_SENSOR_CLASSES,
     EVENT_MAGICAREAS_AREA_STATE_CHANGED,
     INVALID_STATES,
+    MetaAreaIcons,
+    MetaAreaType,
 )
 from .util import add_entities_when_ready
 
@@ -165,6 +167,14 @@ class AreaPresenceBinarySensor(BinarySensorBase):
     @property
     def icon(self):
         """Return the icon to be used for this entity."""
+        if self.area.is_meta():
+            if self.area.id == MetaAreaType.EXTERIOR:
+                return MetaAreaIcons.EXTERIOR
+            if self.area.id == MetaAreaType.INTERIOR:
+                return MetaAreaIcons.INTERIOR
+            if self.area.id == MetaAreaType.GLOBAL:
+                return MetaAreaIcons.GLOBAL
+
         return self.area.icon
 
     @property

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.selector import (
     EntitySelectorConfig,
     selector,
 )
+from homeassistant.util import slugify
 
 from .const import (
     _DOMAIN_SCHEMA,
@@ -49,7 +50,6 @@ from .const import (
     CONF_FEATURE_LIST_GLOBAL,
     CONF_FEATURE_LIST_META,
     CONF_FEATURE_PRESENCE_HOLD,
-    CONF_ICON,
     CONF_ID,
     CONF_INCLUDE_ENTITIES,
     CONF_NOTIFICATION_DEVICES,
@@ -76,7 +76,6 @@ from .const import (
     CONFIGURABLE_AREA_STATE_MAP,
     CONFIGURABLE_FEATURES,
     DATA_AREA_OBJECT,
-    DEFAULT_ICON,
     DOMAIN,
     LIGHT_GROUP_ACT_ON_OPTIONS,
     META_AREA_GLOBAL,
@@ -217,7 +216,7 @@ class ConfigFlow(config_entries.ConfigFlow, ConfigBase, domain=DOMAIN):
         """Handle the initial step."""
         errors = {}
 
-        reserved_names = [meta_area.lower() for meta_area in META_AREAS]
+        reserved_names = [slugify(meta_area) for meta_area in META_AREAS]
 
         # Load registries
         area_registry = self.hass.helpers.area_registry.async_get(self.hass)
@@ -272,7 +271,7 @@ class ConfigFlow(config_entries.ConfigFlow, ConfigBase, domain=DOMAIN):
             config_entry.update(extra_opts)
 
             # Handle Meta area
-            if area_object.normalized_name in reserved_names:
+            if slugify(area_object.name) in reserved_names:
                 _LOGGER.debug(
                     "ConfigFlow: Meta area %s found, setting correct type.",
                     area_object.name,
@@ -455,8 +454,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ConfigBase):
 
                 return await self.async_step_secondary_states()
 
-        icon_selector = selector({"icon": {"placeholder": DEFAULT_ICON}})
-
         all_selectors = {
             CONF_TYPE: self._build_selector_select(
                 sorted([AREA_TYPE_INTERIOR, AREA_TYPE_EXTERIOR])
@@ -476,7 +473,6 @@ class OptionsFlowHandler(config_entries.OptionsFlow, ConfigBase):
             CONF_ON_STATES: self._build_selector_select(
                 sorted(AVAILABLE_ON_STATES), multiple=True
             ),
-            CONF_ICON: icon_selector,
             CONF_UPDATE_INTERVAL: self._build_selector_number(),
             CONF_CLEAR_TIMEOUT: self._build_selector_number(),
         }

--- a/custom_components/magic_areas/config_flow.py
+++ b/custom_components/magic_areas/config_flow.py
@@ -299,7 +299,7 @@ class ConfigFlow(config_entries.ConfigFlow, ConfigBase, domain=DOMAIN):
             [
                 area.name
                 for area in available_areas
-                if area.normalized_name not in reserved_names
+                if slugify(area.name) not in reserved_names
             ]
         )
         available_area_names.extend(
@@ -307,7 +307,7 @@ class ConfigFlow(config_entries.ConfigFlow, ConfigBase, domain=DOMAIN):
                 [
                     f"(Meta) {area.name}"
                     for area in available_areas
-                    if area.normalized_name in reserved_names
+                    if slugify(area.name) in reserved_names
                 ]
             )
         )

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -164,7 +164,6 @@ CONF_AGGREGATES_MIN_ENTITIES, DEFAULT_AGGREGATES_MIN_ENTITIES = (
 )  # cv.positive_int
 CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT = "clear_timeout", 60  # cv.positive_int
 CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL = "update_interval", 60  # cv.positive_int
-CONF_ICON, DEFAULT_ICON = "icon", "mdi:texture-box"  # cv.string
 CONF_NOTIFICATION_DEVICES, DEFAULT_NOTIFICATION_DEVICES = (
     "notification_devices",
     [],
@@ -461,7 +460,6 @@ REGULAR_AREA_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
         ): cv.positive_int,
-        vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
         vol.Optional(CONF_ENABLED_FEATURES, default={}): FEATURES_SCHEMA,
         vol.Optional(CONF_SECONDARY_STATES, default={}): SECONDARY_STATES_SCHEMA,
     }
@@ -479,7 +477,6 @@ META_AREA_SCHEMA = vol.Schema(
         vol.Optional(
             CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL
         ): cv.positive_int,
-        vol.Optional(CONF_ICON, default=DEFAULT_ICON): cv.string,
     }
 )
 
@@ -509,14 +506,12 @@ OPTIONS_AREA = [
     ),
     (CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT, int),
     (CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, int),
-    (CONF_ICON, DEFAULT_ICON, str),
 ]
 
 OPTIONS_AREA_META = [
     (CONF_EXCLUDE_ENTITIES, [], cv.entity_ids),
     (CONF_CLEAR_TIMEOUT, DEFAULT_CLEAR_TIMEOUT, int),
     (CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, int),
-    (CONF_ICON, DEFAULT_ICON, str),
 ]
 
 OPTIONS_SECONDARY_STATES = [

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -1,5 +1,6 @@
 """Constants for Magic Areas."""
 
+from enum import StrEnum
 from itertools import chain
 
 import voluptuous as vol
@@ -63,6 +64,34 @@ ATTR_PRESENCE_SENSORS = "presence_sensors"
 ICON_PRESENCE_HOLD = "mdi:car-brake-hold"
 ICON_LIGHT_CONTROL = "mdi:lightbulb-auto-outline"
 
+
+class MetaAreaIcons(StrEnum):
+    """Meta area icons."""
+
+    INTERIOR = "mdi:home-import-outline"
+    EXTERIOR = "mdi:home-export-outline"
+    GLOBAL = "mdi:home"
+
+
+class FeatureIcons(StrEnum):
+    """Feature related icons."""
+
+    PRESENCE_HOLD_SWITCH = "mdi:car-brake-hold"
+    LIGHT_CONTROL_SWITCH = "mdi:lightbulb-auto-outline"
+
+
+class AreaStates(StrEnum):
+    """Magic area states."""
+
+    CLEAR = "clear"
+    OCCUPIED = "occupied"
+    EXTENDED = "extended"
+    DARK = "dark"
+    BRIGHT = "bright"
+    SLEEP = "sleep"
+    ACCENT = "accented"
+
+
 # Area States
 AREA_STATE_CLEAR = "clear"
 AREA_STATE_OCCUPIED = "occupied"
@@ -101,7 +130,25 @@ MAGIC_AREAS_COMPONENTS_GLOBAL = MAGIC_AREAS_COMPONENTS_META
 
 MAGIC_DEVICE_ID_PREFIX = "magic_area_device_"
 
+
+class AreaType(StrEnum):
+    """Regular area types."""
+
+    INTERIOR = "interior"
+    EXTERIOR = "exterior"
+    META = "meta"
+
+
 # Meta Areas
+class MetaAreaType(StrEnum):
+    """Meta area types."""
+
+    GLOBAL = "global"
+    INTERIOR = "interior"
+    EXTERIOR = "exterior"
+    FLOOR = "floor"
+
+
 META_AREA_GLOBAL = "Global"
 META_AREA_INTERIOR = "Interior"
 META_AREA_EXTERIOR = "Exterior"

--- a/custom_components/magic_areas/translations/de.json
+++ b/custom_components/magic_areas/translations/de.json
@@ -98,7 +98,6 @@
           "presence_sensor_device_class": "Geräteklassen von Anwesenheitssensoren",
           "presence_device_platforms": "Plattformen zur Anwesenheitserfassung",
           "on_states": "Sensorzustände, die Anwesenheit anzeigen",
-          "icon": "Icon",
           "update_interval": "Intervall für die Überprüfung verpasster Ereignisse",
           "clear_timeout": "Wann soll der Bereich nach dem letzten Ereignis frei werden?",
           "type": "Bereichstyp (innen/außen)"

--- a/custom_components/magic_areas/translations/en.json
+++ b/custom_components/magic_areas/translations/en.json
@@ -103,7 +103,6 @@
           "presence_sensor_device_class": "Presence sensors device classes",
           "presence_device_platforms": "Platforms to be used for presence sensing",
           "on_states": "Sensor states that indicate presence",
-          "icon": "Icon",
           "update_interval": "Interval for checking missed events",
           "clear_timeout": "How long since last presence event should it wait before clearing the area",
           "type": "Area type (interior/exterior)"

--- a/custom_components/magic_areas/util.py
+++ b/custom_components/magic_areas/util.py
@@ -19,8 +19,10 @@ basestring = (str, bytes)
 class BasicArea:
     """An interchangeable area object for Magic Areas to consume."""
 
-    id = None
-    name = None
+    id: str
+    name: str | None = None
+    icon: str | None = None
+    floor_id: str | None = None
 
 
 def is_entity_list(item):
@@ -96,7 +98,7 @@ def add_entities_when_ready(hass, async_add_entities, config_entry, callback_fn)
         callback = hass.bus.async_listen(EVENT_MAGICAREAS_AREA_READY, load_entities)
 
 
-def basic_area_from_name(name) -> BasicArea:
+def basic_area_from_name(name: str) -> BasicArea:
     """Create a BasicArea from a name."""
 
     area = BasicArea()
@@ -112,5 +114,7 @@ def basic_area_from_object(area: AreaEntry) -> BasicArea:
     basic_area = BasicArea()
     basic_area.name = area.name
     basic_area.id = area.id
+    basic_area.icon = area.icon
+    basic_area.floor_id = area.floor_id
 
     return basic_area


### PR DESCRIPTION
Areas for a while have icons now, we can just pull from it. For meta areas, MA will provide initial ones that the end-use can customize through HA natively.