### PR TITLE
Fix unit of measurement resolution

### DIFF
--- a/custom_components/magic_areas/sensor.py
+++ b/custom_components/magic_areas/sensor.py
@@ -1,5 +1,6 @@
 """Sensor controls for magic areas."""
 
+from collections import Counter
 import logging
 
 from homeassistant.components.group.sensor import (
@@ -8,14 +9,9 @@ from homeassistant.components.group.sensor import (
     SensorGroup,
     SensorStateClass,
 )
-from homeassistant.components.sensor import (
-    DEVICE_CLASS_UNITS,
-    DOMAIN as SENSOR_DOMAIN,
-    UNIT_CONVERTERS,
-    SensorDeviceClass,
-)
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN, SensorDeviceClass
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_DEVICE_CLASS
+from homeassistant.const import ATTR_DEVICE_CLASS, ATTR_UNIT_OF_MEASUREMENT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -70,6 +66,8 @@ def create_aggregate_sensors(area: MagicArea) -> list[Entity]:
     """Create the aggregate sensors for the area."""
 
     eligible_entities: dict[str, str] = {}
+    unit_of_measurement_map: dict[str, list[str]] = {}
+
     aggregates = []
 
     if SENSOR_DOMAIN not in area.entities:
@@ -86,7 +84,7 @@ def create_aggregate_sensors(area: MagicArea) -> list[Entity]:
             )
             continue
 
-        if "unit_of_measurement" not in entity:
+        if ATTR_UNIT_OF_MEASUREMENT not in entity:
             _LOGGER.debug(
                 "Entity %s does not have unit_of_measurement defined",
                 entity["entity_id"],
@@ -94,8 +92,13 @@ def create_aggregate_sensors(area: MagicArea) -> list[Entity]:
             continue
 
         # Dictionary of sensors by device class.
-        if entity[ATTR_DEVICE_CLASS] not in eligible_entities:
+        device_class = entity[ATTR_DEVICE_CLASS]
+        if device_class not in eligible_entities:
             eligible_entities[entity[ATTR_DEVICE_CLASS]] = []
+
+        # Dictionary of seen unit of measurements by device class.
+        if device_class not in unit_of_measurement_map:
+            unit_of_measurement_map[device_class] = entity[ATTR_UNIT_OF_MEASUREMENT]
 
         eligible_entities[entity[ATTR_DEVICE_CLASS]].append(entity["entity_id"])
 
@@ -120,9 +123,16 @@ def create_aggregate_sensors(area: MagicArea) -> list[Entity]:
             area.slug,
         )
 
+        # Infer most-popular unit of measurement
+        unit_of_measurements = Counter(unit_of_measurement_map[device_class])
+        most_common_unit_of_measurement = unit_of_measurements.most_common(1)[0][0]
+
         aggregates.append(
             AreaAggregateSensor(
-                area=area, device_class=device_class, entity_ids=entities
+                area=area,
+                device_class=device_class,
+                entity_ids=entities,
+                unit_of_measurement=most_common_unit_of_measurement,
             )
         )
 
@@ -137,6 +147,7 @@ class AreaSensorGroupSensor(MagicEntity, SensorGroup):
         area: MagicArea,
         device_class: SensorDeviceClass,
         entity_ids: list[str],
+        unit_of_measurement: str,
     ) -> None:
         """Initialize an area sensor group sensor."""
 
@@ -144,17 +155,14 @@ class AreaSensorGroupSensor(MagicEntity, SensorGroup):
             self, area=area, domain=SENSOR_DOMAIN, translation_key=device_class
         )
 
-        unit_of_measurement = None
+        final_unit_of_measurement = None
 
         # Resolve unit of measurement
         unit_attr_name = f"{device_class}_unit"
         if hasattr(area.hass.config.units, unit_attr_name):
-            unit_of_measurement = getattr(area.hass.config.units, unit_attr_name)
+            final_unit_of_measurement = getattr(area.hass.config.units, unit_attr_name)
         else:
-            if device_class in UNIT_CONVERTERS:
-                unit_of_measurement = UNIT_CONVERTERS[device_class].NORMALIZED_UNIT
-            else:
-                unit_of_measurement = list(DEVICE_CLASS_UNITS[device_class])[0]
+            final_unit_of_measurement = unit_of_measurement
 
         self._attr_suggested_display_precision = DEFAULT_SENSOR_PRECISION
         self.device_class = device_class
@@ -171,7 +179,7 @@ class AreaSensorGroupSensor(MagicEntity, SensorGroup):
                 if device_class in AGGREGATE_MODE_TOTAL_SENSOR
                 else SensorStateClass.MEASUREMENT
             ),
-            unit_of_measurement=unit_of_measurement,
+            unit_of_measurement=final_unit_of_measurement,
             name=None,
             unique_id=self._attr_unique_id,
         )


### PR DESCRIPTION
This fix uses the most popular unit of measurement for a given device class and leaves to the group converter to deal with unit conversions. This means if your sensors are in one unit but you have a few stragglers, those should get converted and properly aggregated.

Removed the bit that checked for the first entry on `list(DEVICE_CLASS_UNITS[device_class])[0]` because the new option is just better (again, this integration is heavily opinionated).

This bug was originally reported by @tbrasser on Discord. His PR #391 and his research behind it were paramount on coming to this. Thanks a lot ❤️ !