### PR TITLE
Fixing broken logic on unit of measurement popularity contest

### DIFF
--- a/custom_components/magic_areas/sensor.py
+++ b/custom_components/magic_areas/sensor.py
@@ -98,9 +98,10 @@ def create_aggregate_sensors(area: MagicArea) -> list[Entity]:
 
         # Dictionary of seen unit of measurements by device class.
         if device_class not in unit_of_measurement_map:
-            unit_of_measurement_map[device_class] = entity[ATTR_UNIT_OF_MEASUREMENT]
+            unit_of_measurement_map[device_class] = []
 
-        eligible_entities[entity[ATTR_DEVICE_CLASS]].append(entity["entity_id"])
+        unit_of_measurement_map[device_class].append(entity[ATTR_UNIT_OF_MEASUREMENT])
+        eligible_entities[device_class].append(entity["entity_id"])
 
     # Create aggregates
     for device_class, entities in eligible_entities.items():

--- a/tests/test_threshold.py
+++ b/tests/test_threshold.py
@@ -1,7 +1,7 @@
 """Test for aggregate (group) sensor behavior."""
 
-import logging
 import asyncio
+import logging
 
 from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN


### PR DESCRIPTION
Instead of ending with a list of unit of measurements I was ending with a ever-overwriting string which resulted in the final unit of measurement being truncated to the first character. 🤦 