### PR TITLE
Fix self._last_active_sensors not updating correctly in AreaStateTracker class

### DIFF
--- a/custom_components/magic_areas/base/presence.py
+++ b/custom_components/magic_areas/base/presence.py
@@ -491,10 +491,10 @@ class AreaStateTrackerEntity(MagicEntity):
                 )
 
         # Populate metadata
-        self._active_sensors = active_sensors
-
         if active_sensors:
-            self._last_active_sensors = active_sensors
+            self._last_active_sensors = self._active_sensors
+
+        self._active_sensors = active_sensors
 
         return len(active_sensors) > 0
 


### PR DESCRIPTION
This pull request addresses a bug in the _get_sensors_state method of the AreaStateTracker class.

Bug Details:
The issue stems from self._last_active_sensors and self._active_sensors holding identical values, which seems incorrect. This behavior undermines the intended logic of tracking the previous sensor state.

Fix Description:
The fix ensures that self._last_active_sensors correctly stores the values of self._active_sensors before the latter is updated. This preserves the expected distinction between the previous and current states of the sensors.

If the current behavior of self._last_active_sensors and self._active_sensors being identical is intended, feel free to close this pull request.

Julien Decoen