### PR TITLE
Add back listener for waiting HA to load

### DIFF
--- a/custom_components/magic_areas/sensor.py
+++ b/custom_components/magic_areas/sensor.py
@@ -20,8 +20,8 @@ from custom_components.magic_areas.base.entities import MagicEntity
 from custom_components.magic_areas.base.magic import MagicArea
 from custom_components.magic_areas.const import (
     AGGREGATE_MODE_SUM,
-    AGGREGATE_MODE_TOTAL_SENSOR,
     AGGREGATE_MODE_TOTAL_INCREASING_SENSOR,
+    AGGREGATE_MODE_TOTAL_SENSOR,
     CONF_AGGREGATES_MIN_ENTITIES,
     CONF_AGGREGATES_SENSOR_DEVICE_CLASSES,
     CONF_FEATURE_AGGREGATION,


### PR DESCRIPTION
Thought I could remove it but looks like the entity registry is not populated beforehand so 🤷 . Will try to look at this again in a later time so I can focus on the new features.