### PR TITLE
Add device registry update listener to reload areas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,7 +60,15 @@ repos:
             "-sn", # Don't display the score
             "--rcfile=pylintrc", # Link to your config file
           ]
-  # - repo: https://github.com/pre-commit/mirrors-mypy
-  #   rev: 'v1.9.0'
-  #   hooks:
-  #   -   id: mypy
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.9.0'
+    hooks:
+    - id: mypy
+      args:
+        - --explicit-package-bases
+        - --strict
+      types: [python]
+      additional_dependencies:
+        - typed
+        - pydantic
+        - returns

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -290,8 +290,7 @@ ALL_SENSOR_DEVICE_CLASSES = [cls.value for cls in SensorDeviceClass]
 
 # Data Items
 DATA_AREA_OBJECT = "area_object"
-DATA_UNDO_UPDATE_LISTENER = "undo_update_listener"
-DATA_ENTITY_LISTENER = "entity_registry_listener"
+DATA_TRACKED_LISTENERS = "tracked_listeners"
 
 # Attributes
 ATTR_STATES = "states"


### PR DESCRIPTION
A previous PR added a listener to the entity registry that reloads the (all) areas when a change is made to the area of an entity. This PR adds the same but for devices.