### PR TITLE
Fix switch dispatch listeners

### DIFF
--- a/custom_components/magic_areas/media_player/__init__.py
+++ b/custom_components/magic_areas/media_player/__init__.py
@@ -177,7 +177,7 @@ class AreaMediaPlayerGroup(MagicEntity, MediaPlayerGroup):
 
         if area_id != self.area.id:
             _LOGGER.debug(
-                "%s: Area state change event not for us. Skipping. (req: %s/self: %s)",
+                "%s: Area state change event not for us. Skipping. (event: %s/self: %s)",
                 self.name,
                 area_id,
                 self.area.id,

--- a/custom_components/magic_areas/switch/climate_control.py
+++ b/custom_components/magic_areas/switch/climate_control.py
@@ -1,5 +1,7 @@
 """Climate control feature switch."""
 
+import logging
+
 from homeassistant.components.climate.const import (
     ATTR_PRESET_MODE,
     DOMAIN as CLIMATE_DOMAIN,
@@ -25,6 +27,8 @@ from custom_components.magic_areas.const import (
     MagicAreasFeatures,
 )
 from custom_components.magic_areas.switch.base import SwitchBase
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class ClimateControlSwitch(SwitchBase):
@@ -88,6 +92,15 @@ class ClimateControlSwitch(SwitchBase):
 
         if not self.is_on:
             self.logger.debug("%s: Control disabled. Skipping.", self.name)
+            return
+
+        if area_id != self.area.id:
+            _LOGGER.debug(
+                "%s: Area state change event not for us. Skipping. (event: %s/self: %s)",
+                self.name,
+                area_id,
+                self.area.id,
+            )
             return
 
         priority_states: list[str] = [

--- a/custom_components/magic_areas/switch/fan_control.py
+++ b/custom_components/magic_areas/switch/fan_control.py
@@ -88,6 +88,15 @@ class FanControlSwitch(SwitchBase):
     async def area_state_changed(self, area_id, states_tuple):
         """Handle area state change event."""
 
+        if area_id != self.area.id:
+            _LOGGER.debug(
+                "%s: Area state change event not for us. Skipping. (event: %s/self: %s)",
+                self.name,
+                area_id,
+                self.area.id,
+            )
+            return
+
         # pylint: disable-next=unused-variable
         new_states, lost_states = states_tuple
         await self.run_logic(states=new_states)


### PR DESCRIPTION
The functions that listens to area change events on the switch entities were lacking a check wether the event area ID matches ours (the event is for our area).

This affected only the new features Fan groups and Climate control. Added where missing.