### PR TITLE
Migrate media player control logic from media player group into switch

### DIFF
--- a/custom_components/magic_areas/media_player/__init__.py
+++ b/custom_components/magic_areas/media_player/__init__.py
@@ -4,19 +4,15 @@ import logging
 
 from homeassistant.components.group.media_player import MediaPlayerGroup
 from homeassistant.components.media_player.const import DOMAIN as MEDIA_PLAYER_DOMAIN
-from homeassistant.components.switch.const import DOMAIN as SWITCH_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, STATE_ON
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
 
 from custom_components.magic_areas.base.entities import MagicEntity
 from custom_components.magic_areas.base.magic import MagicArea
 from custom_components.magic_areas.const import (
-    AREA_STATE_CLEAR,
     CONF_FEATURE_AREA_AWARE_MEDIA_PLAYER,
     CONF_FEATURE_MEDIA_PLAYER_GROUPS,
     CONF_NOTIFICATION_DEVICES,
     DATA_AREA_OBJECT,
-    EVENT_MAGICAREAS_AREA_STATE_CHANGED,
+    EMPTY_STRING,
     META_AREA_GLOBAL,
     MODULE_DATA,
     MagicAreasFeatureInfoMediaPlayerGroups,
@@ -33,10 +29,10 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, config_entry, async_add_entities):
     """Set up the area media player config entry."""
 
-    area: MagicArea = get_area_from_config_entry(hass, config_entry)
+    area: MagicArea | None = get_area_from_config_entry(hass, config_entry)
     assert area is not None
 
-    entities_to_add: list[str] = []
+    entities_to_add: list[AreaAwareMediaPlayer | AreaMediaPlayerGroup] = []
 
     # Media Player Groups
     if area.has_feature(CONF_FEATURE_MEDIA_PLAYER_GROUPS):
@@ -138,68 +134,10 @@ class AreaMediaPlayerGroup(MagicEntity, MediaPlayerGroup):
     def __init__(self, area, entities):
         """Initialize media player group."""
         MagicEntity.__init__(self, area, domain=MEDIA_PLAYER_DOMAIN)
-        # @FIXME use name from translation. Coudln't get it working.
         MediaPlayerGroup.__init__(
             self,
-            name="Media Players",
+            name=EMPTY_STRING,
             unique_id=self._attr_unique_id,
             entities=entities,
         )
-
-        self._entities = entities
-
-        _LOGGER.debug(
-            "%s: Media Player group created with entities: %s",
-            self.area.name,
-            str(self._entities),
-        )
-
-    def _is_control_enabled(self):
-        """Check if media player control is enabled by checking media player control switch state."""
-
-        entity_id = f"{SWITCH_DOMAIN}.magic_areas_media_player_groups_{self.area.slug}_media_player_control"
-        switch_entity = self.hass.states.get(entity_id)
-
-        if not switch_entity:
-            return False
-
-        return switch_entity.state.lower() == STATE_ON
-
-    def area_state_changed(self, area_id, states_tuple):
-        """Handle area state change event."""
-        # pylint: disable-next=unused-variable
-        new_states, lost_states = states_tuple
-
-        # Do nothing if control is disabled
-        if not self._is_control_enabled():
-            _LOGGER.debug("%s: Control disabled, skipping.", self.name)
-            return
-
-        if area_id != self.area.id:
-            _LOGGER.debug(
-                "%s: Area state change event not for us. Skipping. (event: %s/self: %s)",
-                self.name,
-                area_id,
-                self.area.id,
-            )
-            return
-
-        _LOGGER.debug("%s: Media Player group detected area state change.", self.name)
-
-        if AREA_STATE_CLEAR in new_states:
-            _LOGGER.debug("%s: Area clear, turning off media players", self.name)
-            self._turn_off()
-
-    def _turn_off(self):
-        """Turn off all members in group."""
-        service_data = {ATTR_ENTITY_ID: self.entity_id}
-        self.hass.services.call(MEDIA_PLAYER_DOMAIN, SERVICE_TURN_OFF, service_data)
-
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-
-        async_dispatcher_connect(
-            self.hass, EVENT_MAGICAREAS_AREA_STATE_CHANGED, self.area_state_changed
-        )
-
-        await super().async_added_to_hass()
+        delattr(self, "_attr_name")

--- a/custom_components/magic_areas/switch/__init__.py
+++ b/custom_components/magic_areas/switch/__init__.py
@@ -11,13 +11,15 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from custom_components.magic_areas.base.magic import MagicArea
 from custom_components.magic_areas.const import (
     MagicAreasFeatureInfoLightGroups,
-    MagicAreasFeatureInfoMediaPlayerGroups,
     MagicAreasFeatures,
 )
 from custom_components.magic_areas.helpers.area import get_area_from_config_entry
 from custom_components.magic_areas.switch.base import SwitchBase
 from custom_components.magic_areas.switch.climate_control import ClimateControlSwitch
 from custom_components.magic_areas.switch.fan_control import FanControlSwitch
+from custom_components.magic_areas.switch.media_player_control import (
+    MediaPlayerControlSwitch,
+)
 from custom_components.magic_areas.switch.presence_hold import PresenceHoldSwitch
 from custom_components.magic_areas.util import cleanup_removed_entries
 
@@ -87,11 +89,4 @@ class LightControlSwitch(SwitchBase):
     """Switch to enable/disable light control."""
 
     feature_info = MagicAreasFeatureInfoLightGroups()
-    _attr_entity_category = EntityCategory.CONFIG
-
-
-class MediaPlayerControlSwitch(SwitchBase):
-    """Switch to enable/disable media player control."""
-
-    feature_info = MagicAreasFeatureInfoMediaPlayerGroups()
     _attr_entity_category = EntityCategory.CONFIG

--- a/custom_components/magic_areas/switch/media_player_control.py
+++ b/custom_components/magic_areas/switch/media_player_control.py
@@ -1,0 +1,72 @@
+"""Media player control feature switch."""
+
+import logging
+
+from homeassistant.const import ATTR_ENTITY_ID, EntityCategory, SERVICE_TURN_OFF
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.components.media_player.const import DOMAIN as MEDIA_PLAYER_DOMAIN
+from custom_components.magic_areas.base.magic import MagicArea
+
+from custom_components.magic_areas.const import (
+    AreaStates,
+    MagicAreasEvents,
+    MagicAreasFeatureInfoMediaPlayerGroups,
+)
+from custom_components.magic_areas.switch.base import SwitchBase
+from tests.const import DEFAULT_MOCK_AREA
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class MediaPlayerControlSwitch(SwitchBase):
+    """Switch to enable/disable climate control."""
+
+    feature_info = MagicAreasFeatureInfoMediaPlayerGroups()
+    _attr_entity_category = EntityCategory.CONFIG
+
+    media_player_group_id: str
+
+    def __init__(self, area: MagicArea) -> None:
+        """Initialize the Climate control switch."""
+
+        SwitchBase.__init__(self, area)
+
+        self.media_player_group_id = f"{MEDIA_PLAYER_DOMAIN}.magic_areas_media_player_groups_{DEFAULT_MOCK_AREA}_media_player_group"
+
+    async def async_added_to_hass(self) -> None:
+        """Call when entity about to be added to hass."""
+        await super().async_added_to_hass()
+
+        self.async_on_remove(
+            async_dispatcher_connect(
+                self.hass, MagicAreasEvents.AREA_STATE_CHANGED, self.area_state_changed
+            )
+        )
+
+    async def area_state_changed(self, area_id, states_tuple):
+        """Handle area state change event."""
+
+        if not self.is_on:
+            self.logger.debug("%s: Control disabled. Skipping.", self.name)
+            return
+
+        if area_id != self.area.id:
+            _LOGGER.debug(
+                "%s: Area state change event not for us. Skipping. (event: %s/self: %s)",
+                self.name,
+                area_id,
+                self.area.id,
+            )
+            return
+
+        # pylint: disable-next=unused-variable
+        new_states, lost_states = states_tuple
+
+        if AreaStates.CLEAR in new_states:
+            _LOGGER.debug("%s: Area clear, turning off media players.", self.name)
+            await self.hass.services.async_call(
+                MEDIA_PLAYER_DOMAIN,
+                SERVICE_TURN_OFF,
+                {ATTR_ENTITY_ID: self.media_player_group_id},
+            )
+            return


### PR DESCRIPTION
Self-explanatory. This simplifies the media group by being as close to native as possible with the switch listening to area changes and issuing service calls to turn it off.