### PR TITLE
Reload meta-areas on regular-area load

### DIFF
--- a/custom_components/magic_areas/binary_sensor/presence.py
+++ b/custom_components/magic_areas/binary_sensor/presence.py
@@ -620,7 +620,7 @@ class AreaStateBinarySensor(AreaStateTrackerEntity, BinarySensorEntity):
         _LOGGER.debug("%s: area presence binary sensor initialized", self.area.name)
 
     async def _setup_listeners(self) -> None:
-        # Setup state chagne listener
+        # Setup state change listener
         async_dispatcher_connect(
             self.hass, MagicAreasEvents.AREA_STATE_CHANGED, self._area_state_changed
         )

--- a/custom_components/magic_areas/const.py
+++ b/custom_components/magic_areas/const.py
@@ -331,6 +331,7 @@ class MagicAreasEvents(StrEnum):
     """Magic Areas events."""
 
     AREA_STATE_CHANGED = "magicareas_area_state_changed"
+    AREA_LOADED = "magicareas_area_loaded"
 
 
 EVENT_MAGICAREAS_AREA_STATE_CHANGED = "magicareas_area_state_changed"


### PR DESCRIPTION
Meta-areas suffer from race condition on load. This PR aims to solve that by adding a listener to meta-areas to reload whenever an area of the same time loads (or reloads).